### PR TITLE
sdk: Make camera read from INI file the nb of bits for AB, Depth, Conf

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -798,6 +798,12 @@ aditof::Status CameraItof::loadConfigData(void) {
             m_depthSensor->setControl("abBits", value);
         }
 
+        value = iniFileContentFindKeyAndGetValue(depthIniStream, "partialDepthEnable");
+        if (!value.empty()) {
+            std::string en = (value == "0") ? "1" : "0";
+            m_depthSensor->setControl("DEPTH_EN", en);
+        }
+
         // XYZ set through camera control takes precedence over the setting from .ini file
         if (!m_xyzSetViaControl) {
             m_xyzEnabled = iniFileContentFindKeyAndGetValue(depthIniStream, "xyzEnable") == "1";

--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -331,6 +331,17 @@ class CameraItof : public aditof::Camera {
      */
     aditof::Status updateAdsd3500Firmware(const std::string &filePath);
 
+    /**
+     * INI files have key value pairs like this:
+     * enableSomething = 1
+     * someThresholdValue = 200.5
+     * The content of the INI files is expected to be stored the variable given as parameter.
+     * @param[in] iniContent - the content of an INI file
+     * @param[in] key - the key to be search and get its value
+     * @return the value of the key
+    */
+    std::string iniFileContentFindKeyAndGetValue(std::ifstream &iniContent, const std::string &key);
+
   private:
     using noArgCallable = std::function<aditof::Status()>;
 


### PR DESCRIPTION
These options read from INI file will be used to configure the ADSD3500.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>