### PR TITLE
sdcard-images-utils: Add versions file and generate licences.txt list

### DIFF
--- a/sdcard-images-utils/nxp/deboot.sh
+++ b/sdcard-images-utils/nxp/deboot.sh
@@ -212,12 +212,12 @@ echo -e "${PASSWORD}\n${PASSWORD}\n" | passwd ${USERNAME}
 
 # overwrite apt source list
 rm -f /etc/apt/sources.list
-echo deb     ${DISTRO_MIRROR} ${DISTRO_CODE}          main restricted universe multiverse >> /etc/apt/sources.list
-echo deb-src ${DISTRO_MIRROR} ${DISTRO_CODE}          main restricted universe multiverse >> /etc/apt/sources.list
-echo deb     ${DISTRO_MIRROR} ${DISTRO_CODE}-updates  main restricted universe multiverse >> /etc/apt/sources.list
-echo deb-src ${DISTRO_MIRROR} ${DISTRO_CODE}-updates  main restricted universe multiverse >> /etc/apt/sources.list
-echo deb     ${DISTRO_MIRROR} ${DISTRO_CODE}-security main restricted universe multiverse >> /etc/apt/sources.list
-echo deb-src ${DISTRO_MIRROR} ${DISTRO_CODE}-security main restricted universe multiverse >> /etc/apt/sources.list
+echo deb     ${DISTRO_MIRROR} ${DISTRO_CODE}          main universe >> /etc/apt/sources.list
+echo deb-src ${DISTRO_MIRROR} ${DISTRO_CODE}          main universe >> /etc/apt/sources.list
+echo deb     ${DISTRO_MIRROR} ${DISTRO_CODE}-updates  main universe >> /etc/apt/sources.list
+echo deb-src ${DISTRO_MIRROR} ${DISTRO_CODE}-updates  main universe >> /etc/apt/sources.list
+echo deb     ${DISTRO_MIRROR} ${DISTRO_CODE}-security main universe >> /etc/apt/sources.list
+echo deb-src ${DISTRO_MIRROR} ${DISTRO_CODE}-security main universe >> /etc/apt/sources.list
 
 apt update -y
 apt upgrade -y
@@ -244,6 +244,8 @@ popd
 popd
 popd
 
+#generate licences file
+tail -n 10000 /usr/share/doc/*/copyright > /licenses.txt
 EOF
 
   # Apply step1 overlay

--- a/sdcard-images-utils/nxp/runme.sh
+++ b/sdcard-images-utils/nxp/runme.sh
@@ -122,6 +122,10 @@ env PATH="$PATH:/sbin:/usr/sbin" mkdosfs tmp/part1.fat32
 
 IMG=microsd-${REPO_PREFIX}.img
 
+echo "sd_img_ver	$IMG" > $ROOTDIR/images/sw-versions
+echo "kernel		$KERNEL_NXP_REL" >> $ROOTDIR/images/sw-versions
+echo "u-boot		$UBOOT_NXP_REL" >> $ROOTDIR/images/sw-versions
+
 echo "label linux" > $ROOTDIR/images/extlinux.conf
 echo "        linux ../Image" >> $ROOTDIR/images/extlinux.conf
 echo "        fdt ../imx8mp-adi-tof-noreg.dtb" >> $ROOTDIR/images/extlinux.conf
@@ -131,6 +135,7 @@ else
 	echo "        append root=/dev/mmcblk1p2 rootwait rw" >> $ROOTDIR/images/extlinux.conf
 fi
 mmd -i tmp/part1.fat32 ::/extlinux
+mcopy -i tmp/part1.fat32 $ROOTDIR/images/sw-versions ::/sw-versions
 mcopy -i tmp/part1.fat32 $ROOTDIR/images/extlinux.conf ::/extlinux/extlinux.conf
 mcopy -i tmp/part1.fat32 $ROOTDIR/build/linux-imx/arch/arm64/boot/Image ::/Image
 mcopy -s -i tmp/part1.fat32 $ROOTDIR/build/linux-imx/arch/arm64/boot/dts/freescale/*imx8mp*.dtb ::/


### PR DESCRIPTION
This PR create a sw-versions file in FAT partition for easyer identification of flashed SD card image
and also disable restricted and multiverse repos and generate a file with licences of all installed rootfs apps.