### PR TITLE
apps/server: Cleanup server if client didn't hang up

### DIFF
--- a/apps/server/server.cpp
+++ b/apps/server/server.cpp
@@ -54,6 +54,7 @@ static std::vector<std::shared_ptr<aditof::StorageInterface>> storages;
 static std::vector<std::shared_ptr<aditof::TemperatureSensorInterface>>
     temperatureSensors;
 bool sensors_are_created = false;
+bool clientEngagedWithSensors = false;
 
 /* Server only works with one depth sensor */
 std::shared_ptr<aditof::DepthSensorInterface> camDepthSensor;
@@ -96,6 +97,7 @@ static void cleanup_sensors() {
     camDepthSensor.reset();
 
     sensors_are_created = false;
+    clientEngagedWithSensors = false;
 }
 
 Network ::Network() : context(nullptr) {}
@@ -291,6 +293,11 @@ void invoke_sdk_api(payload::ClientRequest buff_recv) {
     switch (s_map_api_Values[buff_recv.func_name()]) {
 
     case FIND_SENSORS: {
+        // Check if client didn't hang up (why would want to search for sensor if it already tried to open one)
+        if (clientEngagedWithSensors) {
+            cleanup_sensors();   
+        }
+
         if (!sensors_are_created) {
             auto sensorsEnumerator =
                 aditof::SensorEnumeratorFactory::buildTargetSensorEnumerator();
@@ -357,6 +364,7 @@ void invoke_sdk_api(payload::ClientRequest buff_recv) {
     case OPEN: {
         aditof::Status status = camDepthSensor->open();
         buff_send.set_status(static_cast<::payload::Status>(status));
+        clientEngagedWithSensors = true;
         break;
     }
 
@@ -517,6 +525,7 @@ void invoke_sdk_api(payload::ClientRequest buff_recv) {
         status = storages[index]->open(sensorHandle);
 
         buff_send.set_status(static_cast<::payload::Status>(status));
+        clientEngagedWithSensors = true;
         break;
     }
 
@@ -602,6 +611,7 @@ void invoke_sdk_api(payload::ClientRequest buff_recv) {
         status = temperatureSensors[index]->open(sensorHandle);
 
         buff_send.set_status(static_cast<::payload::Status>(status));
+        clientEngagedWithSensors = true;
         break;
     }
 


### PR DESCRIPTION
Client might crash (so won't hang up) and next time will try to find
sensors (which are already opened for communication). So check if
client didn't hang up and cleanup sensors and start fresh.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>