### PR TITLE
Frame rate was being limited by how the depth and point cloud windows

### DIFF
--- a/examples/tof-viewer/src/ADIMainWindow.cpp
+++ b/examples/tof-viewer/src/ADIMainWindow.cpp
@@ -1363,7 +1363,6 @@ void ADIMainWindow::PlayCCD(int modeSelect, int viewSelect) {
 		if (displayDepth) {
 			displayIR = false;			
 			synchronizePointCloudVideo();
-			synchronizeDepthIRVideo();	
 			displayPointCloudWindow(overlayFlags);
 			displayDepthWindow(overlayFlags);
 		} else {
@@ -1707,6 +1706,7 @@ void ADIMainWindow::synchronizePointCloudVideo() {
 	view->m_capturedFrame->getDetails(frameDetails);
 	std::unique_lock<std::mutex> lock(view->m_frameCapturedMutex);
 
+	view->m_depthFrameAvailable = true;
 	view->m_pointCloudFrameAvailable = true;
 	view->frameHeight = frameDetails.height;
 	view->frameWidth = frameDetails.width;
@@ -1718,7 +1718,7 @@ void ADIMainWindow::synchronizePointCloudVideo() {
 	/*********************************/
 	std::unique_lock<std::mutex> imshow_lock(view->m_imshowMutex);
 	view->m_barrierCv.wait(imshow_lock,
-			[&]() { return view->m_waitKeyBarrier == 1/*view->numOfThreads*/; });
+			[&]() { return view->m_waitKeyBarrier == view->numOfThreads; });
 	view->m_waitKeyBarrier = 0;
 	/*********************************/
 }

--- a/examples/tof-viewer/src/ADIView.cpp
+++ b/examples/tof-viewer/src/ADIView.cpp
@@ -539,7 +539,7 @@ void ADIView::_displayPointCloudImage()
 
 		std::unique_lock<std::mutex> imshow_lock(m_imshowMutex);
 		m_waitKeyBarrier += 1;
-		if (m_waitKeyBarrier == 1/*numOfThreads*/) {
+		if (m_waitKeyBarrier == numOfThreads) {
 			imshow_lock.unlock();
 			m_barrierCv.notify_one();
 		}


### PR DESCRIPTION
The framerate of the point cloud and depth combination was limited to half that of the AB and depth combination - when using a decent GPU such as NVIDIA as opposed to an integrated GPU. This limitation was due to how the code treated point cloud and depth vs AB and depth. Point cloud and depth is now treated in the same manner as AB and depth. Point cloud and depth is now at the same rate as AB and depth. However, point cloud rendering is impacted by GPU activity.