### PR TITLE
sdk/target: Change format based on mode ("qmp" or "mp")

### DIFF
--- a/sdk/src/connections/target/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500_sensor.cpp
@@ -435,10 +435,19 @@ Adsd3500Sensor::setFrameType(const aditof::DepthSensorFrameType &type) {
             return status;
         }
 
+        __u32 pixelFormat;
+        if (type.type == "qmp") {
+            pixelFormat = V4L2_PIX_FMT_SBGGR8;
+        } else if (type.type == "mp") {
+            pixelFormat = V4L2_PIX_FMT_SBGGR12;
+        } else {
+            LOG(ERROR) << "frame type: " << type.type << " " << "is unhandled";
+        }
+
         /* Set the frame format in the driver */
         CLEAR(fmt);
         fmt.type = dev->videoBuffersType;
-        fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_SBGGR8;
+        fmt.fmt.pix.pixelformat = pixelFormat;
         fmt.fmt.pix.width = type.width;
         fmt.fmt.pix.height = type.height;
 


### PR DESCRIPTION
This is not a complete solution. There can be multiple formats for
"qmp". Same applies for "mp". Formats vary based on the number of AB,
depth and confidence bits that are set via .ini file.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>