### PR TITLE
sdk: src: camera_itof.cpp: Fix dealias for mode 10

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -223,14 +223,8 @@ aditof::Status CameraItof::initialize() {
             //the first element of readback_data for adsd3500_read_payload is used for the custom command
             //it will be overwritten by the returned data
             uint8_t mode = ModeInfo::getInstance()->getModeInfo(availableFrameTypes.type).mode;
-
-            if (mode != 10) {
-                intrinsics[0] = mode;
-                dealiasParams[0] = mode;
-            } else {
-                intrinsics[0] = 5;
-                dealiasParams[0] = 5;
-            }
+            intrinsics[0] = mode;
+            dealiasParams[0] = mode;
 
             //hardcoded function values to return intrinsics
             status = m_depthSensor->adsd3500_read_payload_cmd(0x01, intrinsics, 56);


### PR DESCRIPTION
ADSD3500 firmware is responding as expected to mode 10
dealias parameters. So remove using of mode 5 parameters
on mode 10 data.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>