### PR TITLE
sdk/camera_itof: copy ab data to buffer for mp only if ab is enabled

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -377,6 +377,7 @@ class CameraItof : public aditof::Camera {
     std::string m_ccb_calibrationFile;
     std::string m_ini_depth;
     std::map <std::string, std::string> m_ini_depth_map;
+    bool m_abEnabled;
     bool m_xyzEnabled;
     bool m_xyzSetViaControl;
     uint16_t m_modechange_framedrop_count = 0;


### PR DESCRIPTION
Signed-off-by: SeptimiuVana <Vana.Septimiu@analog.com>