### PR TITLE
sdk/network: Close the detached thread before Network gets destroyed

### DIFF
--- a/sdk/src/connections/network/network.h
+++ b/sdk/src/connections/network/network.h
@@ -59,6 +59,7 @@ class Network {
     static bool Send_Successful[MAX_CAMERA_NUM];
     static bool Data_Received[MAX_CAMERA_NUM];
     static bool Server_Connected[MAX_CAMERA_NUM];
+    static bool Thread_Detached[MAX_CAMERA_NUM];
 
     int Thread_Running[MAX_CAMERA_NUM];
 


### PR DESCRIPTION
This fixes the issue where SDK would crash if unable to connect to
server (maybe wrong IP or server not up yet).

Signed-off-by: Dan Nechita <dan.nechita@analog.com>