### PR TITLE
SD card image generator fixes

### DIFF
--- a/sdcard-images-utils/nxp/patches/uboot-imx/0001-Add-imx8mp-solidrun-configuration-files-to-u-boot.patch
+++ b/sdcard-images-utils/nxp/patches/uboot-imx/0001-Add-imx8mp-solidrun-configuration-files-to-u-boot.patch
@@ -1,7 +1,7 @@
-From 0103c6e0f882844b9b56a90c7097fe707610be4a Mon Sep 17 00:00:00 2001
+From dabe42efef1e07b52a50c51ff45b33053b9186f3 Mon Sep 17 00:00:00 2001
 From: TalPilo <tal.pilo@solid-run.com>
 Date: Wed, 30 Sep 2020 11:38:11 +0300
-Subject: [PATCH 1/3] Add imx8mp solidrun configuration files to u-boot
+Subject: [PATCH 01/11] Add imx8mp solidrun configuration files to u-boot
 
 Signed-off-by: TalPilo <tal.pilo@solid-run.com>
 ---
@@ -3269,5 +3269,5 @@ index 0000000000..e7206e56f7
 +
 +#endif
 -- 
-2.25.1
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/uboot-imx/0003-Add-imx8mp-solidrun-board-to-uboot-configuration.patch
+++ b/sdcard-images-utils/nxp/patches/uboot-imx/0003-Add-imx8mp-solidrun-board-to-uboot-configuration.patch
@@ -1,7 +1,7 @@
-From ffb315cf084c3ecb86716c1d14594969ea6a4d7f Mon Sep 17 00:00:00 2001
+From 26a47162fb54690022bd76d67a07af92ee7a1475 Mon Sep 17 00:00:00 2001
 From: Rabeeh Khoury <rabeeh@solid-run.com>
 Date: Mon, 1 Feb 2021 19:33:05 +0200
-Subject: [PATCH 3/3] Add imx8mp solidrun board to uboot configuration
+Subject: [PATCH 03/11] Add imx8mp solidrun board to uboot configuration
 
 Signed-off-by: Rabeeh Khoury <rabeeh@solid-run.com>
 ---
@@ -11,7 +11,7 @@ Signed-off-by: Rabeeh Khoury <rabeeh@solid-run.com>
  3 files changed, 8 insertions(+)
 
 diff --git a/arch/arm/Kconfig b/arch/arm/Kconfig
-index 377aaeeb..94e08b23 100644
+index 377aaeebb7..94e08b23e8 100644
 --- a/arch/arm/Kconfig
 +++ b/arch/arm/Kconfig
 @@ -1822,6 +1822,7 @@ source "arch/arm/cpu/armv8/Kconfig"
@@ -23,7 +23,7 @@ index 377aaeeb..94e08b23 100644
  source "board/bosch/guardian/Kconfig"
  source "board/CarMediaLab/flea3/Kconfig"
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 0d24acd4..30dbf744 100644
+index 0d24acd457..30dbf74406 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
 @@ -796,6 +796,7 @@ dtb-$(CONFIG_ARCH_IMX8M) += \
@@ -35,7 +35,7 @@ index 0d24acd4..30dbf744 100644
  	imx8mm-ab2.dtb \
  	imx8mn-ddr4-ab2.dtb \
 diff --git a/arch/arm/mach-imx/imx8m/Kconfig b/arch/arm/mach-imx/imx8m/Kconfig
-index 41c68a49..2cd0e06a 100644
+index 41c68a49a3..2cd0e06a11 100644
 --- a/arch/arm/mach-imx/imx8m/Kconfig
 +++ b/arch/arm/mach-imx/imx8m/Kconfig
 @@ -124,6 +124,12 @@ config TARGET_IMX8MP_DDR4_EVK
@@ -52,5 +52,5 @@ index 41c68a49..2cd0e06a 100644
  	bool "imx8mm LPDDR4 Audio board 2.0"
  	select IMX8MM
 -- 
-2.25.1
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/uboot-imx/0004-fix-name-of-dtb-file-for-i.MX8MP-HummingBoard-Pulse.patch
+++ b/sdcard-images-utils/nxp/patches/uboot-imx/0004-fix-name-of-dtb-file-for-i.MX8MP-HummingBoard-Pulse.patch
@@ -1,7 +1,7 @@
-From e2ffba349e58e0b589602642e5865ed621ca2f58 Mon Sep 17 00:00:00 2001
+From 4f33299c88ec3e5079ade1b7ad4c1f29e273dae6 Mon Sep 17 00:00:00 2001
 From: Josua Mayer <josua.mayer@jm0.eu>
 Date: Sun, 1 Nov 2020 14:05:21 +0100
-Subject: [PATCH 1/2] fix name of dtb file for i.MX8MP HummingBoard Pulse
+Subject: [PATCH 04/11] fix name of dtb file for i.MX8MP HummingBoard Pulse
 
 ---
  configs/imx8mp_solidrun_defconfig | 2 +-
@@ -35,5 +35,5 @@ index e7206e56f7..a1e2c47dfe 100644
          "fdt_addr_r=0x43000000\0" \
          "fdt_addr=0x43000000\0" \
 -- 
-2.29.2
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/uboot-imx/0005-imx8mp-add-eqos-ethernet-port-and-disable-fec.patch
+++ b/sdcard-images-utils/nxp/patches/uboot-imx/0005-imx8mp-add-eqos-ethernet-port-and-disable-fec.patch
@@ -1,7 +1,7 @@
-From 6858072066e641d860be2f3831e6597ce7743043 Mon Sep 17 00:00:00 2001
+From 41fd82cdb1e6f2cf2b43ed4b1c667290dde0b59e Mon Sep 17 00:00:00 2001
 From: Rabeeh Khoury <rabeeh@solid-run.com>
 Date: Mon, 23 Nov 2020 20:42:17 +0200
-Subject: [PATCH 5/5] imx8mp: add eqos ethernet port and disable fec
+Subject: [PATCH 05/11] imx8mp: add eqos ethernet port and disable fec
 
 eqos port is the main ethernet port connected from the SOM and exported
 on the HummingBoard mate/pulse and all it's variants.
@@ -156,5 +156,5 @@ index a1e2c47dfe..b31310204c 100644
  #define CONFIG_SYS_NONCACHED_MEMORY     (1 * SZ_1M)     /* 1M */
  #endif
 -- 
-2.25.1
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/uboot-imx/0006-imx8mp-add-memory-size-detection.patch
+++ b/sdcard-images-utils/nxp/patches/uboot-imx/0006-imx8mp-add-memory-size-detection.patch
@@ -1,7 +1,7 @@
-From fd819d6bb8c3d51d02e02b85a572a1b851c2af4b Mon Sep 17 00:00:00 2001
+From 6aed6e1be1fd09e2ffc86ab70e7a9e5ec361a658 Mon Sep 17 00:00:00 2001
 From: Rabeeh Khoury <rabeeh@solid-run.com>
 Date: Mon, 14 Dec 2020 14:57:16 +0200
-Subject: [PATCH] imx8mp: add memory size detection
+Subject: [PATCH 06/11] imx8mp: add memory size detection
 
 SolidRun supports Samsung 1GByte at 4Gtps and Micron 3GByte at 3.2Gtps
 speeds.
@@ -28,7 +28,7 @@ Signed-off-by: Rabeeh Khoury <rabeeh@solid-run.com>
  rename board/solidrun/imx8mp_solidrun/{lpddr4_timing.c => lpddr4_timing_3gb_micron.c} (98%)
 
 diff --git a/board/solidrun/imx8mp_solidrun/Makefile b/board/solidrun/imx8mp_solidrun/Makefile
-index 7cbe536f..6ef4c05b 100644
+index 7cbe536f88..6ef4c05b40 100644
 --- a/board/solidrun/imx8mp_solidrun/Makefile
 +++ b/board/solidrun/imx8mp_solidrun/Makefile
 @@ -8,5 +8,5 @@ obj-y += imx8mp_solidrun.o mmc.o
@@ -39,7 +39,7 @@ index 7cbe536f..6ef4c05b 100644
 +obj-$(CONFIG_IMX8M_LPDDR4) += lpddr4_timing_3gb_micron.o lpddr4_timing_1gb_samsung.o
  endif
 diff --git a/board/solidrun/imx8mp_solidrun/imx8mp_solidrun.c b/board/solidrun/imx8mp_solidrun/imx8mp_solidrun.c
-index dcfe6a2b..51a5cbad 100644
+index dcfe6a2b37..51a5cbade6 100644
 --- a/board/solidrun/imx8mp_solidrun/imx8mp_solidrun.c
 +++ b/board/solidrun/imx8mp_solidrun/imx8mp_solidrun.c
 @@ -28,6 +28,9 @@
@@ -83,7 +83,7 @@ index dcfe6a2b..51a5cbad 100644
  	struct wdog_regs *wdog = (struct wdog_regs *)WDOG1_BASE_ADDR;
 diff --git a/board/solidrun/imx8mp_solidrun/lpddr4_timing_1gb_samsung.c b/board/solidrun/imx8mp_solidrun/lpddr4_timing_1gb_samsung.c
 new file mode 100644
-index 00000000..efc81678
+index 0000000000..efc8167817
 --- /dev/null
 +++ b/board/solidrun/imx8mp_solidrun/lpddr4_timing_1gb_samsung.c
 @@ -0,0 +1,1854 @@
@@ -1945,7 +1945,7 @@ diff --git a/board/solidrun/imx8mp_solidrun/lpddr4_timing.c b/board/solidrun/imx
 similarity index 98%
 rename from board/solidrun/imx8mp_solidrun/lpddr4_timing.c
 rename to board/solidrun/imx8mp_solidrun/lpddr4_timing_3gb_micron.c
-index 42571625..11f53af7 100644
+index 425716250d..11f53af7af 100644
 --- a/board/solidrun/imx8mp_solidrun/lpddr4_timing.c
 +++ b/board/solidrun/imx8mp_solidrun/lpddr4_timing_3gb_micron.c
 @@ -11,7 +11,7 @@
@@ -2021,7 +2021,7 @@ index 42571625..11f53af7 100644
  	.ddrc_cfg_num = ARRAY_SIZE(ddr_ddrc_cfg),
  	.ddrphy_cfg = ddr_ddrphy_cfg,
 diff --git a/board/solidrun/imx8mp_solidrun/spl.c b/board/solidrun/imx8mp_solidrun/spl.c
-index b26f5321..c215cf64 100644
+index b26f5321bb..c215cf64bf 100644
 --- a/board/solidrun/imx8mp_solidrun/spl.c
 +++ b/board/solidrun/imx8mp_solidrun/spl.c
 @@ -25,8 +25,12 @@
@@ -2071,5 +2071,5 @@ index b26f5321..c215cf64 100644
  
  #define I2C_PAD_CTRL (PAD_CTL_DSE6 | PAD_CTL_HYS | PAD_CTL_PUE | PAD_CTL_PE)
 -- 
-2.25.1
+2.17.1
 

--- a/sdcard-images-utils/nxp/patches/uboot-imx/0007-LFU-143-tcpc-Add-i2c-read-write-return-check.patch
+++ b/sdcard-images-utils/nxp/patches/uboot-imx/0007-LFU-143-tcpc-Add-i2c-read-write-return-check.patch
@@ -1,7 +1,7 @@
-From 434e495d4475d31524b261ecf268b52d23a55470 Mon Sep 17 00:00:00 2001
+From 63dc79b4f387a48e1b9e03be8113221290598937 Mon Sep 17 00:00:00 2001
 From: Ye Li <ye.li@nxp.com>
 Date: Thu, 27 May 2021 03:13:14 -0700
-Subject: [PATCH 1/2] LFU-143 tcpc: Add i2c read/write return check
+Subject: [PATCH 07/11] LFU-143 tcpc: Add i2c read/write return check
 
 Fix coverity Issue: 2970631/5409463 Unchecked return value.
 Add relevant return check for i2c read and write

--- a/sdcard-images-utils/nxp/patches/uboot-imx/0008-imx8mp_solidrun-Enable-USB-Type-C-controller.patch
+++ b/sdcard-images-utils/nxp/patches/uboot-imx/0008-imx8mp_solidrun-Enable-USB-Type-C-controller.patch
@@ -1,7 +1,7 @@
-From 8efd2c325bf279df5359993df6c5f13d9b4aafc7 Mon Sep 17 00:00:00 2001
+From ba99654e27b2c55db6008c7d4889ba06115b6373 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 15 Sep 2021 10:47:11 +0300
-Subject: [PATCH 2/2] imx8mp_solidrun: Enable USB Type C controller
+Subject: [PATCH 08/11] imx8mp_solidrun: Enable USB Type C controller
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/uboot-imx/0009-board-solidrun-common-tcpc-Handle-DISCOVER_IDENTITY-.patch
+++ b/sdcard-images-utils/nxp/patches/uboot-imx/0009-board-solidrun-common-tcpc-Handle-DISCOVER_IDENTITY-.patch
@@ -1,7 +1,8 @@
-From 5cdfb83adc4c05d0f38846b6a39d0f62090bfb7e Mon Sep 17 00:00:00 2001
+From 173f8935517d83c940f9f750f9fe42389b418e7b Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 3 Mar 2022 16:47:31 +0200
-Subject: [PATCH] board: solidrun: common: tcpc: Handle DISCOVER_IDENTITY VDM
+Subject: [PATCH 09/11] board: solidrun: common: tcpc: Handle DISCOVER_IDENTITY
+ VDM
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/uboot-imx/0010-arch-arm-dts-Add-ADI-devicetree.patch
+++ b/sdcard-images-utils/nxp/patches/uboot-imx/0010-arch-arm-dts-Add-ADI-devicetree.patch
@@ -1,20 +1,34 @@
-From ddff7b0a77c668af73e65c72c303e66b195fd7cb Mon Sep 17 00:00:00 2001
-From: TalPilo <tal.pilo@solid-run.com>
-Date: Wed, 30 Sep 2020 11:38:40 +0300
-Subject: [PATCH 02/11] Add imx8mp solidrun device tree to u-boot
+From 79fe5130e28f832fc6ab28faecb7ec36e7b437fb Mon Sep 17 00:00:00 2001
+From: Bogdan Togorean <bogdan.togorean@analog.com>
+Date: Fri, 1 Jul 2022 09:16:59 +0300
+Subject: [PATCH 10/11] arch: arm: dts: Add ADI devicetree
 
-Signed-off-by: TalPilo <tal.pilo@solid-run.com>
+Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
- arch/arm/dts/imx8mp-solidrun.dts | 571 +++++++++++++++++++++++++++++++
- 1 file changed, 571 insertions(+)
- create mode 100644 arch/arm/dts/imx8mp-solidrun.dts
+ arch/arm/dts/Makefile             |   1 +
+ arch/arm/dts/imx8mp-adi.dts       | 580 ++++++++++++++++++++++++++++++
+ configs/imx8mp_solidrun_defconfig |  10 +-
+ 3 files changed, 584 insertions(+), 7 deletions(-)
+ create mode 100644 arch/arm/dts/imx8mp-adi.dts
 
-diff --git a/arch/arm/dts/imx8mp-solidrun.dts b/arch/arm/dts/imx8mp-solidrun.dts
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 30dbf74406..b12624047c 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -796,6 +796,7 @@ dtb-$(CONFIG_ARCH_IMX8M) += \
+ 	imx8mq-evk.dtb \
+ 	imx8mp-ddr4-evk.dtb \
+ 	imx8mp-evk.dtb \
++	imx8mp-adi.dtb \
+ 	imx8mp-solidrun.dtb \
+ 	imx8mm-ddr4-ab2.dtb \
+ 	imx8mm-ab2.dtb \
+diff --git a/arch/arm/dts/imx8mp-adi.dts b/arch/arm/dts/imx8mp-adi.dts
 new file mode 100644
-index 0000000000..44726378e4
+index 0000000000..59f67d2900
 --- /dev/null
-+++ b/arch/arm/dts/imx8mp-solidrun.dts
-@@ -0,0 +1,571 @@
++++ b/arch/arm/dts/imx8mp-adi.dts
+@@ -0,0 +1,580 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright 2020 SolidRun ltd.
@@ -86,16 +100,28 @@ index 0000000000..44726378e4
 +		startup-delay-us = <100>;
 +		off-on-delay-us = <12000>;
 +	};
++
++	reg_vcc_3p3: regulator-vcc-3p3 {
++		compatible = "regulator-fixed";
++		pinctrl-names = "default";
++		regulator-name = "VCC_3P3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio5 2 GPIO_ACTIVE_HIGH>;
++		startup-delay-us = <100>;
++		off-on-delay-us = <1200>;
++		enable-active-high;
++		regulator-always-on;
++	};
 +};
 +
-+/* ETH0 */
 +&fec {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&pinctrl_fec>;
 +	phy-mode = "rgmii-id";
 +	phy-handle = <&ethphy1>;
 +	fsl,magic-packet;
-+	status = "okay";
++	status = "disabled";
 +
 +	mdio {
 +		#address-cells = <1>;
@@ -109,23 +135,28 @@ index 0000000000..44726378e4
 +	};
 +};
 +
-+/* need to check*/
-+&flexspi {
++&eqos {
 +	pinctrl-names = "default";
-+	pinctrl-0 = <&pinctrl_flexspi0>;
++	pinctrl-0 = <&pinctrl_eqos>;
++	phy-mode = "rgmii-id";
++	phy-handle = <&ethphy0>;
 +	status = "okay";
++        compatible = "fsl,imx-eqos";
++        /delete-property/ assigned-clocks;
++        /delete-property/ assigned-clock-parents;
++        /delete-property/ assigned-clock-rates;
 +
-+	flash0: mt25qu256aba@0 {
-+		reg = <0>;
++	mdio {
 +		#address-cells = <1>;
-+		#size-cells = <1>;
-+		compatible = "jedec,spi-nor";
-+		spi-max-frequency = <80000000>;
-+		spi-tx-bus-width = <4>;
-+		spi-rx-bus-width = <4>;
++		#size-cells = <0>;
++
++		ethphy0: ethernet-phy@0 {
++			compatible = "ethernet-phy-ieee802.3-c22";
++			reg = <0>;
++			eee-broken-1000t;
++		};
 +	};
 +};
-+
 +
 +&i2c1 {
 +	clock-frequency = <400000>;
@@ -135,6 +166,12 @@ index 0000000000..44726378e4
 +	scl-gpios = <&gpio5 14 GPIO_ACTIVE_HIGH>;
 +	sda-gpios = <&gpio5 15 GPIO_ACTIVE_HIGH>;
 +	status = "okay";
++
++	eeprom: eeprom@50 {
++		compatible = "atmel,24c02";
++		reg = <0x50>;
++		pagesize = <16>;
++	};
 +
 +	pmic: pca9450@25 {
 +		reg = <0x25>;
@@ -252,20 +289,6 @@ index 0000000000..44726378e4
 +	scl-gpios = <&gpio5 16 GPIO_ACTIVE_HIGH>;
 +	sda-gpios = <&gpio5 17 GPIO_ACTIVE_HIGH>;
 +	status = "okay";
-+
-+	adv_bridge: adv7535@39 {
-+		compatible = "adi,adv7533";
-+		reg = <0x39>;
-+		adi,addr-cec = <0x3c>;
-+		adi,dsi-lanes = <4>;
-+		status = "okay";
-+
-+		port {
-+			adv7535_from_dsim: endpoint {
-+				remote-endpoint = <&dsim_to_adv7535>;
-+			};
-+		};
-+	};
 +};
 +
 +&i2c3 {
@@ -276,28 +299,14 @@ index 0000000000..44726378e4
 +	scl-gpios = <&gpio5 18 GPIO_ACTIVE_HIGH>;
 +	sda-gpios = <&gpio5 19 GPIO_ACTIVE_HIGH>;
 +	status = "okay";
-+
-+	pca6416: gpio@20 {
-+		compatible = "ti,tca6416";
-+		reg = <0x20>;
-+		gpio-controller;
-+		#gpio-cells = <2>;
-+	};
 +};
 +
 +&lcdif1 {
-+	status = "okay";
++	status = "disabled";
 +};
 +
 +&mipi_dsi {
-+	status = "okay";
-+
-+	port@1 {
-+		dsim_to_adv7535: endpoint {
-+			remote-endpoint = <&adv7535_from_dsim>;
-+		};
-+	};
-+
++	status = "disabled";
 +};
 +
 +&snvs_pwrkey {
@@ -363,6 +372,26 @@ index 0000000000..44726378e4
 +
 +&iomuxc {
 +	pinctrl-names = "default";
++
++	pinctrl_eqos: eqosgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_ENET_MDC__ENET_QOS_MDC		0x3
++			MX8MP_IOMUXC_ENET_MDIO__ENET_QOS_MDIO		0x3
++			MX8MP_IOMUXC_ENET_RD0__ENET_QOS_RGMII_RD0	0x91
++			MX8MP_IOMUXC_ENET_RD1__ENET_QOS_RGMII_RD1	0x91
++			MX8MP_IOMUXC_ENET_RD2__ENET_QOS_RGMII_RD2	0x91
++			MX8MP_IOMUXC_ENET_RD3__ENET_QOS_RGMII_RD3	0x91
++			MX8MP_IOMUXC_ENET_RXC__CCM_ENET_QOS_CLOCK_GENERATE_RX_CLK	0x91
++			MX8MP_IOMUXC_ENET_RX_CTL__ENET_QOS_RGMII_RX_CTL	0x91
++			MX8MP_IOMUXC_ENET_TD0__ENET_QOS_RGMII_TD0	0x1f
++			MX8MP_IOMUXC_ENET_TD1__ENET_QOS_RGMII_TD1	0x1f
++			MX8MP_IOMUXC_ENET_TD2__ENET_QOS_RGMII_TD2	0x1f
++			MX8MP_IOMUXC_ENET_TD3__ENET_QOS_RGMII_TD3	0x1f
++			MX8MP_IOMUXC_ENET_TX_CTL__ENET_QOS_RGMII_TX_CTL	0x1f
++			MX8MP_IOMUXC_ENET_TXC__CCM_ENET_QOS_CLOCK_GENERATE_TX_CLK	0x1f
++			MX8MP_IOMUXC_SAI1_TXD7__GPIO4_IO19		0x19
++		>;
++	};
 +
 +	pinctrl_fec: fecgrp {
 +		fsl,pins = <
@@ -456,12 +485,6 @@ index 0000000000..44726378e4
 +	pinctrl_pmic: pmicirq {
 +		fsl,pins = <
 +			MX8MP_IOMUXC_GPIO1_IO03__GPIO1_IO03	0x41
-+		>;
-+	};
-+
-+	pinctrl_typec: typec1grp {
-+		fsl,pins = <
-+			MX8MP_IOMUXC_SAI1_TXD7__GPIO4_IO19	0x1c4
 +		>;
 +	};
 +
@@ -586,6 +609,45 @@ index 0000000000..44726378e4
 +		>;
 +	};
 +};
+diff --git a/configs/imx8mp_solidrun_defconfig b/configs/imx8mp_solidrun_defconfig
+index 2001b445e0..e4eb41c316 100644
+--- a/configs/imx8mp_solidrun_defconfig
++++ b/configs/imx8mp_solidrun_defconfig
+@@ -27,7 +27,7 @@ CONFIG_SPL_LOAD_FIT=y
+ CONFIG_SPL_FIT_GENERATOR="arch/arm/mach-imx/mkimage_fit_atf.sh"
+ CONFIG_OF_SYSTEM_SETUP=y
+ CONFIG_SYS_EXTRA_OPTIONS="IMX_CONFIG=arch/arm/mach-imx/imx8m/imximage-8mp-lpddr4.cfg"
+-CONFIG_DEFAULT_FDT_FILE="imx8mp-hummingboard-pulse.dtb"
++CONFIG_DEFAULT_FDT_FILE="imx8mp-adi-tof-adsd3500.dtb"
+ CONFIG_BOARD_LATE_INIT=y
+ CONFIG_BOARD_EARLY_INIT_F=y
+ CONFIG_SPL_BOARD_INIT=y
+@@ -61,7 +61,7 @@ CONFIG_CMD_FAT=y
+ CONFIG_CMD_SF=y
+ CONFIG_CMD_LED=y
+ CONFIG_OF_CONTROL=y
+-CONFIG_DEFAULT_DEVICE_TREE="imx8mp-solidrun"
++CONFIG_DEFAULT_DEVICE_TREE="imx8mp-adi"
+ CONFIG_ENV_IS_IN_MMC=y
+ CONFIG_ENV_IS_IN_SPI_FLASH=y
+ CONFIG_ENV_IS_NOWHERE=y
+@@ -143,11 +143,6 @@ CONFIG_OF_BOARD_SETUP=y
+ 
+ CONFIG_REGMAP=y
+ CONFIG_SYSCON=y
+-CONFIG_VIDEO_IMX_LCDIFV3=y
+-CONFIG_VIDEO_IMX_SEC_DSI=y
+-CONFIG_DM_VIDEO=y
+-CONFIG_VIDEO_LCD_RAYDIUM_RM67191=y
+-CONFIG_VIDEO_ADV7535=y
+ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_TARGET_IMX8MP_SOLIDRUN=y
+ CONFIG_BOOTP_BOOTPATH=y
+@@ -163,3 +158,4 @@ CONFIG_BOOTCOMMAND="run distro_bootcmd"
+ CONFIG_CMD_PXE=y
+ CONFIG_ENV_SIZE=0x2000
+ CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_I2C_EEPROM=y
 -- 
 2.17.1
 

--- a/sdcard-images-utils/nxp/patches/uboot-imx/0011-configs-imx8mp_solidrun_defoncifg-Set-boot-delay-to-.patch
+++ b/sdcard-images-utils/nxp/patches/uboot-imx/0011-configs-imx8mp_solidrun_defoncifg-Set-boot-delay-to-.patch
@@ -1,0 +1,25 @@
+From 0dd7dee0549249b2fe4ade4774497a741387fdf3 Mon Sep 17 00:00:00 2001
+From: Bogdan Togorean <bogdan.togorean@analog.com>
+Date: Fri, 1 Jul 2022 09:25:49 +0300
+Subject: [PATCH 11/11] configs: imx8mp_solidrun_defoncifg: Set boot delay to 0
+
+Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
+---
+ configs/imx8mp_solidrun_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/imx8mp_solidrun_defconfig b/configs/imx8mp_solidrun_defconfig
+index e4eb41c316..1b60da17c7 100644
+--- a/configs/imx8mp_solidrun_defconfig
++++ b/configs/imx8mp_solidrun_defconfig
+@@ -145,6 +145,7 @@ CONFIG_REGMAP=y
+ CONFIG_SYSCON=y
+ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_TARGET_IMX8MP_SOLIDRUN=y
++CONFIG_BOOTDELAY=0
+ CONFIG_BOOTP_BOOTPATH=y
+ CONFIG_BOOTP_DNS=y
+ CONFIG_BOOTP_GATEWAY=y
+-- 
+2.17.1
+

--- a/sdcard-images-utils/nxp/patches/ubuntu_overlay/step3/etc/fstab
+++ b/sdcard-images-utils/nxp/patches/ubuntu_overlay/step3/etc/fstab
@@ -1,0 +1,8 @@
+# /etc/fstab: static file system information.
+#
+# Use 'blkid' to print the universally unique identifier for a device; this may
+# be used with UUID= as a more robust way to name devices that works even if
+# disks are added and removed. See fstab(5).
+#
+# <file system>             <mount point>  <type>  <options>  <dump>  <pass>
+/dev/mmcblk1p1              /boot          vfat defaults,noatime  0     2


### PR DESCRIPTION
1. Disable video in u-boot (no ADV7535 available on NXP carrier)
2. Auto mount /boot
3. Set u-boot delay timer to 0