### PR TITLE
Adsd3500 network connect issue

### DIFF
--- a/sdk/src/connections/network/network.cpp
+++ b/sdk/src/connections/network/network.cpp
@@ -184,7 +184,7 @@ int Network::ServerConnect(const std::string &ip) {
     std::unique_lock<std::recursive_mutex> mlock(m_mutex[m_connectionId]);
 
     /*Wait till server is connected or timeout of 3 sec*/
-    if (Cond_Var[m_connectionId].wait_for(mlock, std::chrono::seconds(10),
+    if (Cond_Var[m_connectionId].wait_for(mlock, std::chrono::seconds(3),
                           std::bind(&Network::isServer_Connected, this)) ==
         false) {
         Server_Connected[m_connectionId] = false;

--- a/sdk/src/connections/network/network_sensor_enumerator.cpp
+++ b/sdk/src/connections/network/network_sensor_enumerator.cpp
@@ -56,8 +56,9 @@ Status NetworkSensorEnumerator::searchSensors() {
 
     if (net->ServerConnect(m_ip) != 0) {
         LOG(WARNING) << "Server Connect Failed";
-        net.reset();
-        sensorCount = 0;
+        net.reset(nullptr);
+        sensorCount--;
+        assert(sensorCount >= 0);
         return Status::UNREACHABLE;
     }
 

--- a/sdk/src/connections/network/network_sensor_enumerator.cpp
+++ b/sdk/src/connections/network/network_sensor_enumerator.cpp
@@ -56,6 +56,8 @@ Status NetworkSensorEnumerator::searchSensors() {
 
     if (net->ServerConnect(m_ip) != 0) {
         LOG(WARNING) << "Server Connect Failed";
+        net.reset();
+        sensorCount = 0;
         return Status::UNREACHABLE;
     }
 


### PR DESCRIPTION
Network connection was still having issues. If the device was not connected the system became unresponsive and the Viewer would not connect even when the device was ready.

* Reduced the connection time from 10s to 3s. Although a better way to do this would be to modify the Viewer, that is coming next.
* Clean up if the network connection fails.