### PR TITLE
Avoid formatting drivers with clang-format

### DIFF
--- a/.clangformatignore
+++ b/.clangformatignore
@@ -1,6 +1,7 @@
 apps/uvc-app/include
 apps/uvc-app/lib
 bindings/python/pybind11
+drivers/
 examples/data_collect/third_party
 examples/tof-viewer/external
 examples/tof-viewer/include/stb_image.h


### PR DESCRIPTION
Signed-off-by: SeptimiuVana <Vana.Septimiu@analog.com>