### PR TITLE
initial commit

### DIFF
--- a/bindings/python/aditofpython.cpp
+++ b/bindings/python/aditofpython.cpp
@@ -277,7 +277,10 @@ PYBIND11_MODULE(aditofpython, m) {
 
                 return status;
             },
-            py::arg("tempSensors"));
+            py::arg("tempSensors"))
+        .def("adsd3500_set_toggle_mode",
+             &aditof::Camera::adsd3500_set_toggle_mode, py::arg("mode"))
+        .def("adsd3500_toggle_fsync", &aditof::Camera::adsd3500_toggle_fsync);
 
     // Frame
     py::class_<aditof::Frame>(m, "Frame")

--- a/sdk/include/aditof/camera.h
+++ b/sdk/include/aditof/camera.h
@@ -182,6 +182,19 @@ class SDK_API Camera {
      */
     virtual Status getTemperatureSensors(
         std::vector<std::shared_ptr<TemperatureSensorInterface>> &sensors) = 0;
+
+    /**
+     * @brief Enables or disables FSYNC toggle for ADSD3500
+     * @param[in] mode - 2 = Fsync pin set as HiZ ; 1 = Toggle at user specified framerate ; 0 = Toggle controlled via adsd3500_toggle_fsync ; 
+     * @return Status
+     */
+    virtual Status adsd3500_set_toggle_mode(int mode) = 0;
+
+    /**
+     * @brief Toggles ADSD3500 FSYNC once if automated FSYNC is disabled
+     * @return Status
+     */
+    virtual Status adsd3500_toggle_fsync() = 0;
 };
 
 } // namespace aditof

--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -139,8 +139,8 @@ class CameraItof : public aditof::Camera {
     aditof::Status getTemperatureSensors(
         std::vector<std::shared_ptr<aditof::TemperatureSensorInterface>>
             &sensors) override;
-    aditof::Status CameraItof::adsd3500_set_toggle_mode(int mode);
-    aditof::Status CameraItof::adsd3500_toggle_fsync();
+    aditof::Status adsd3500_set_toggle_mode(int mode);
+    aditof::Status adsd3500_toggle_fsync();
 
     // TO DO - The methods bellow need to be converted somehow to be covered by setControl()
     // in order to not go beyond Camera API

--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -139,6 +139,8 @@ class CameraItof : public aditof::Camera {
     aditof::Status getTemperatureSensors(
         std::vector<std::shared_ptr<aditof::TemperatureSensorInterface>>
             &sensors) override;
+    aditof::Status CameraItof::adsd3500_set_toggle_mode(int mode);
+    aditof::Status CameraItof::adsd3500_toggle_fsync();
 
     // TO DO - The methods bellow need to be converted somehow to be covered by setControl()
     // in order to not go beyond Camera API
@@ -378,6 +380,7 @@ class CameraItof : public aditof::Camera {
     bool m_eepromInitialized;
     bool m_tempSensorInitialized;
     bool m_adsd3500Enabled;
+    bool m_adsd3500_master;
 
     FileData m_calData;
     FileData m_depthINIData;


### PR DESCRIPTION
- Tested with one camera, adsd3500 can work in slave configuration where the host is triggering fsync instead of the adsd3500
