### PR TITLE
ToF: sdcard-images-utils: nxp: deboot.sh: Add missing user groups

### DIFF
--- a/sdcard-images-utils/nxp/deboot.sh
+++ b/sdcard-images-utils/nxp/deboot.sh
@@ -207,7 +207,9 @@ echo aditof > /etc/hostname
 
 # create user and passwd
 useradd -m -d /home/${USERNAME} -s /bin/bash ${USERNAME}
-usermod -a -G sudo,video,disk,i2c ${USERNAME}
+groupadd i2c
+groupadd gpio
+usermod -a -G sudo,video,disk,i2c,gpio ${USERNAME}
 echo -e "${PASSWORD}\n${PASSWORD}\n" | passwd ${USERNAME}
 
 # overwrite apt source list


### PR DESCRIPTION
Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>