### PR TITLE
examples/tof-viewer: Don't wait for camera ready

### DIFF
--- a/examples/tof-viewer/include/ADIMainWindow.h
+++ b/examples/tof-viewer/include/ADIMainWindow.h
@@ -486,13 +486,6 @@ class ADIMainWindow {
     void prepareCamera(std::string mode);
 
     /**
-		* @brief	Waits until current camera is not in the 
-		*			BUSY status, and changes to OK. If an error
-		*			is detected, will return false, else true.
-		*/
-    bool waitForCameraReady();
-
-    /**
 		* @brief Displays the Information Window
 		*/
     void displayInfoWindow(ImGuiWindowFlags overlayFlags);

--- a/examples/tof-viewer/src/ADIMainWindow.cpp
+++ b/examples/tof-viewer/src/ADIMainWindow.cpp
@@ -1342,30 +1342,6 @@ void ADIMainWindow::prepareCamera(std::string mode) {
     cameraWorkerDone = true;
 }
 
-bool ADIMainWindow::waitForCameraReady() {
-    aditof::Status status = aditof::Status::OK;
-    aditof::Frame temp_frame;
-
-    aditof::FrameDetails frameDetails;
-    // If the frames received are for previous MP mode, discard it and request after 2s( this value is app dependent)
-    // Once got the proper frame, stop requesting
-    while (1) {
-        status = getActiveCamera()->requestFrame(&temp_frame);
-
-        if (status == aditof::Status::BUSY) {
-            LOG(INFO) << "Mode is changing. Waiting for new valid frames !";
-        } else if (status != aditof::Status::OK) {
-            LOG(ERROR) << "Could not request frame!";
-            return false;
-        } else {
-            LOG(INFO) << "succesfully requested frame!";
-            return true;
-        }
-
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    }
-}
-
 void ADIMainWindow::InitCCDCamera() {
     std::string version = aditof::getApiVersion();
     my_log.AddLog("Preparing camera. Please wait...\n");
@@ -1406,10 +1382,6 @@ void ADIMainWindow::PlayCCD(int modeSelect, int viewSelect) {
             captureSeparateEnabled = false;
             modeSelectChanged = modeSelect;
 
-            if (!waitForCameraReady()) {
-                stopPlayCCD();
-                return;
-            }
         } else if (viewSelectionChanged != viewSelect) {
             viewSelectionChanged = viewSelect;
             openGLCleanUp();


### PR DESCRIPTION
1st reason to remove this:
It's not clear why this is required. The function that changes the mode is a blocking type function. Once it finishes the execution, the camera should be in the new mode.

2nd reason to remove this:
The function to wait for camera calls getFrame but at the same time there is a thread that also calls getFrame. This messes things up (especially depth compute) as neither depth compute nor geFrame are thread safe.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>