### PR TITLE
scripts: nxp: setup.sh: Don't install python2 and change CMAKE options

### DIFF
--- a/scripts/nxp/setup.sh
+++ b/scripts/nxp/setup.sh
@@ -25,7 +25,7 @@ print_help() {
 }
 
 install_required_packages() {
-        sudo apt install -y build-essential cmake python-dev python3-dev \
+        sudo apt install -y build-essential cmake python3-dev \
         libssl-dev git
 }
 
@@ -129,7 +129,7 @@ setup() {
         build_and_install_protobuf ${deps_dir}/protobuf ${deps_install_dir}/protobuf
         build_and_install_websockets ${deps_dir}/libwebsockets ${deps_install_dir}/websockets
 
-        CMAKE_OPTIONS="-DUSE_ITOF=1 -DNXP=1"
+        CMAKE_OPTIONS="-DUSE_ITOF=1 -DNXP=1 -DUSE_DEPTH_COMPUTE_STUBS=1 -DWITH_NETWORK=1 -DWITH_PYTHON=1"
         PREFIX_PATH="${deps_install_dir}/glog;${deps_install_dir}/protobuf;${deps_install_dir}/websockets;"
 
         pushd "${build_dir}"


### PR DESCRIPTION
Remove Python 2 from install list
Enable on default build: stubs, network and python bindings

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>