### PR TITLE
sdcard-images-utils: nxp: runme.sh: Copy only ADI devicetree

### DIFF
--- a/sdcard-images-utils/nxp/runme.sh
+++ b/sdcard-images-utils/nxp/runme.sh
@@ -150,7 +150,7 @@ mmd -i tmp/part1.fat32 ::/extlinux
 mcopy -i tmp/part1.fat32 $ROOTDIR/images/sw-versions ::/sw-versions
 mcopy -i tmp/part1.fat32 $ROOTDIR/images/extlinux.conf ::/extlinux/extlinux.conf
 mcopy -i tmp/part1.fat32 $ROOTDIR/build/linux-imx/arch/arm64/boot/Image ::/Image
-mcopy -s -i tmp/part1.fat32 $ROOTDIR/build/linux-imx/arch/arm64/boot/dts/freescale/*imx8mp*.dtb ::/
+mcopy -s -i tmp/part1.fat32 $ROOTDIR/build/linux-imx/arch/arm64/boot/dts/freescale/imx8mp-adi*.dtb ::/
 if [[ $BUILD_TYPE == "buildroot" ]]; then
 	mcopy -s -i tmp/part1.fat32 $ROOTDIR/build/buildroot/output/images/rootfs.cpio.uboot ::/
 fi


### PR DESCRIPTION
Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>