### PR TITLE
Included relevant header for windows to fix ssize_t not found 

### DIFF
--- a/bindings/python/aditofpython.cpp
+++ b/bindings/python/aditofpython.cpp
@@ -35,6 +35,10 @@
 #include "pybind11/stl.h"
 
 #include <aditof/aditof.h>
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
 
 namespace py = pybind11;
 


### PR DESCRIPTION
This is described in detail in: #204 