### PR TITLE
apps: uvc-app: Fix SEG_FAULT on stream stop

### DIFF
--- a/apps/uvc-app/lib/stream.c
+++ b/apps/uvc-app/lib/stream.c
@@ -121,6 +121,8 @@ static int uvc_stream_stop(struct uvc_stream *stream)
 
 	printf("Stopping video stream.\n");
 
+	events_stop(stream->events);
+
 	events_unwatch_fd(stream->events, sink->fd, EVENT_WRITE);
 
 	v4l2_stream_off(sink);


### PR DESCRIPTION
Fix for SEGMENTATION FAULT when UVC stream is stopped. The events list was still processed but events pointers are null.
Also add mechanism for graceful closing and cleaning on SIGINT (CTRL + C).

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>