### PR TITLE
sdcard-images-utils: Add ADSD3030 support

### DIFF
--- a/sdcard-images-utils/nxp/patches/linux-imx/0001-Enable-I2C-in-PMIC.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0001-Enable-I2C-in-PMIC.patch
@@ -1,7 +1,7 @@
-From 58ea8674d0cb1e06caf39cec63c4887b694f2566 Mon Sep 17 00:00:00 2001
+From 71c27e738ad4c4aad6fbc86a9a9c00f68626cabf Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 15 Apr 2021 11:26:07 +0300
-Subject: [PATCH 01/44] Enable I2C in PMIC
+Subject: [PATCH 01/45] Enable I2C in PMIC
 
 Signed-off-by: TalPilo <tal.pilo@solid-run.com>
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -28,5 +28,5 @@ index d59305a6dd41..fe4f8d73b594 100644
  		const struct regulator_desc *desc;
  		struct regulator_dev *rdev;
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0002-media-spi-Add-initial-support-for-addicmos-camera.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0002-media-spi-Add-initial-support-for-addicmos-camera.patch
@@ -1,7 +1,7 @@
-From 75d6ee339c1bfd000e0507ce2fa249b5fd890f95 Mon Sep 17 00:00:00 2001
+From 3bda718808e79936c6420f64ca58171111a89c4f Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 11 Mar 2021 11:26:52 +0200
-Subject: [PATCH 02/44] media: spi: Add initial support for addicmos camera
+Subject: [PATCH 02/45] media: spi: Add initial support for addicmos camera
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -1003,5 +1003,5 @@ index a184c4939438..21e3b433856a 100644
  /* The MPEG controls are applicable to all codec controls
   * and the 'MPEG' part of the define is historical */
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0003-Changes-for-ADI-camera-required-on-I.MX8M-Plus-captu.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0003-Changes-for-ADI-camera-required-on-I.MX8M-Plus-captu.patch
@@ -1,7 +1,7 @@
-From badc4bfdaec8f0da4cc670c71f68468d140f0a47 Mon Sep 17 00:00:00 2001
+From 23887a00e90977aab90e57c245a6fd144f8c4b80 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 11 Mar 2021 11:35:17 +0200
-Subject: [PATCH 03/44] Changes for ADI camera required on I.MX8M Plus capture
+Subject: [PATCH 03/45] Changes for ADI camera required on I.MX8M Plus capture
  driver
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -93,5 +93,5 @@ index 928c64d3be49..b187fa5f4e09 100644
  	return 0;
  }
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0004-drivers-staging-media-imx8-Convert-to-single-planar.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0004-drivers-staging-media-imx8-Convert-to-single-planar.patch
@@ -1,7 +1,7 @@
-From f8f739e1a4dd5e3f10ad6f217498fbd4c7543182 Mon Sep 17 00:00:00 2001
+From d688743cc5f2f72b566d6c1bf8bce9b713cc4df0 Mon Sep 17 00:00:00 2001
 From: btogorean <bogdan.togorean@analog.com>
 Date: Wed, 7 Apr 2021 11:44:38 +0300
-Subject: [PATCH 04/44] drivers: staging: media: imx8: Convert to single planar
+Subject: [PATCH 04/45] drivers: staging: media: imx8: Convert to single planar
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -389,5 +389,5 @@ index 5796deda3df8..9d51ff0cf60d 100644
  
  	val = readl(mxc_isi->regs + CHNL_OUT_BUF_CTRL);
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0005-Convert-pixel-format-to-YUYV.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0005-Convert-pixel-format-to-YUYV.patch
@@ -1,7 +1,7 @@
-From 7777a88df4fdbfaed06ddedc9929db22293ceb9c Mon Sep 17 00:00:00 2001
+From ae348f487cb902e98f35417533c19ae4624da575 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 22 Apr 2021 09:36:10 +0300
-Subject: [PATCH 05/44] Convert pixel format to YUYV
+Subject: [PATCH 05/45] Convert pixel format to YUYV
 
 Signed-off-by: btogorean <bogdan.togorean@analog.com>
 ---
@@ -50,5 +50,5 @@ index e1728e758bcc..3e7691e0253f 100644
  		.memplanes	= 1,
  		.colplanes	= 1,
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0007-staging-media-imx-imx8-isi-cap-Fix-for-discarding-of.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0007-staging-media-imx-imx8-isi-cap-Fix-for-discarding-of.patch
@@ -1,7 +1,7 @@
-From c48986736b94c2d79edc0fcdf9a82c50b045ba05 Mon Sep 17 00:00:00 2001
+From cac8076e8e72f770be11a456293eb0e5bdc786bf Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 4 May 2021 10:20:23 +0300
-Subject: [PATCH 07/44] staging: media: imx: imx8-isi-cap : Fix for discarding
+Subject: [PATCH 07/45] staging: media: imx: imx8-isi-cap : Fix for discarding
  of the first frame
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -29,5 +29,5 @@ index 3e7691e0253f..f8069914af4a 100644
  	/* ISI channel output buffer 2 */
  	buf = list_first_entry(&isi_cap->out_pending, struct mxc_isi_buffer, list);
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0008-drivers-usb-gadget-Add-XU-control-descriptor.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0008-drivers-usb-gadget-Add-XU-control-descriptor.patch
@@ -1,7 +1,7 @@
-From be9e7fa42b004cf84f493fb195f80937b87d7ae8 Mon Sep 17 00:00:00 2001
+From ec69ceda2fec22c2120ecd56335112b1bf89cc42 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 21 May 2021 11:49:25 +0300
-Subject: [PATCH 08/44] drivers: usb: gadget: Add XU control descriptor
+Subject: [PATCH 08/45] drivers: usb: gadget: Add XU control descriptor
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -149,5 +149,5 @@ index bfdae12cdacf..f82080a16345 100644
  } __attribute__((__packed__));
  
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0009-drivers-staging-media-imx-imx8-isi-cap-Add-debug-msg.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0009-drivers-staging-media-imx-imx8-isi-cap-Add-debug-msg.patch
@@ -1,7 +1,7 @@
-From 6fab52ba9af75071d397b65db535157e18a33542 Mon Sep 17 00:00:00 2001
+From 7fea2e5f8a1996f9a1b89baa6f4b23710d1a975b Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 21 May 2021 12:05:06 +0300
-Subject: [PATCH 09/44] drivers: staging: media: imx: imx8-isi-cap: Add debug
+Subject: [PATCH 09/45] drivers: staging: media: imx: imx8-isi-cap: Add debug
  msg for dropped frames
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -22,5 +22,5 @@ index f8069914af4a..5f02d3280408 100644
  		list_move_tail(isi_cap->out_discard.next, &isi_cap->out_active);
  		return;
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0010-drivers-media-spi-addicmos-Add-resolutions-for-max-f.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0010-drivers-media-spi-addicmos-Add-resolutions-for-max-f.patch
@@ -1,7 +1,7 @@
-From ff4e059fedd4e0e49d81efbbaf0778314b40509a Mon Sep 17 00:00:00 2001
+From ee227e7a7c81393ed1b05a54fcd47851a0c5f1f8 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 21 May 2021 12:07:14 +0300
-Subject: [PATCH 10/44] drivers: media: spi: addicmos: Add resolutions for max
+Subject: [PATCH 10/45] drivers: media: spi: addicmos: Add resolutions for max
  frames FW
 
 When firmware configured for setting frame-end only after all
@@ -45,5 +45,5 @@ index e6bbb45d8116..94a37e3bdd07 100644
  };
  
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0011-arch-arm64-dts-imx8mp-aditof-noreg-Allow-PD-up-to-20.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0011-arch-arm64-dts-imx8mp-aditof-noreg-Allow-PD-up-to-20.patch
@@ -1,7 +1,7 @@
-From aabcf80d8320fefe65e1e3cfd8d60519af2e2412 Mon Sep 17 00:00:00 2001
+From 993eacd4a10efc80641b613466d063e9baa0e02d Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 21 May 2021 12:10:33 +0300
-Subject: [PATCH 11/44] arch: arm64: dts: imx8mp-aditof-noreg: Allow PD up to
+Subject: [PATCH 11/45] arch: arm64: dts: imx8mp-aditof-noreg: Allow PD up to
  20V and add SPI flash
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -13,7 +13,7 @@ diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts b/arch/arm64
 index ae0e5bb9eeae..28924e4bc0f9 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
-@@ -215,7 +215,7 @@
+@@ -215,7 +215,7 @@ usb3_data_ss: endpoint {
  
  	mpcie {
  		pinctrl-names = "default";
@@ -22,7 +22,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  		gpio-0 = <&gpio1 1 GPIO_ACTIVE_HIGH>;
  		gpio-1 = <&gpio1 5 GPIO_ACTIVE_HIGH>;
  		status = "okay";
-@@ -239,23 +239,23 @@
+@@ -239,23 +239,23 @@ &snvs_rtc{
  
  /*eth0*/
  &eqos {
@@ -63,7 +63,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  };
  
  &i2c1 {
-@@ -265,10 +265,10 @@
+@@ -265,10 +265,10 @@ &i2c1 {
  	status = "okay";
  
  	eeprom: eeprom@50{
@@ -78,7 +78,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  
  	pmic: pca9450@25 {
  		reg = <0x25>;
-@@ -437,20 +437,21 @@
+@@ -437,20 +437,21 @@ mipi_csi0_ep: endpoint {
  };
  
  &ecspi2 {
@@ -106,7 +106,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  
  		port {
  			addicmos_ep: endpoint {
-@@ -461,6 +462,18 @@
+@@ -461,6 +462,18 @@ addicmos_ep: endpoint {
  			};
  		};
  	};
@@ -125,7 +125,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  };
  
  &isp_0 {
-@@ -499,9 +512,9 @@
+@@ -499,9 +512,9 @@ usb_con: connector {
  			compatible = "usb-c-connector";
  			label = "USB-C";
  			power-role = "sink";
@@ -137,7 +137,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  			op-sink-microwatt = <15000000>;
  
  			ports {
-@@ -712,7 +725,7 @@
+@@ -712,7 +725,7 @@ &usdhc3 {
  	pinctrl-2 = <&pinctrl_usdhc3_200mhz>;
  	bus-width = <8>;
  	non-removable;
@@ -146,7 +146,7 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  };
  
  &wdog1 {
-@@ -1077,19 +1090,31 @@
+@@ -1077,19 +1090,31 @@ MX8MP_IOMUXC_GPIO1_IO06__GPIO1_IO06		0x19
  
  	pinctrl_ecspi2: ecspi2grp {
  		fsl,pins = <
@@ -181,5 +181,5 @@ index ae0e5bb9eeae..28924e4bc0f9 100644
  		fsl,pins = <
  			MX8MP_IOMUXC_SPDIF_RX__GPIO5_IO04		0x140
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0012-usb-typec-tcpm-Remove-tcpm-port-reset.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0012-usb-typec-tcpm-Remove-tcpm-port-reset.patch
@@ -1,7 +1,7 @@
-From 7aa1892563409a745261276943f55e791119c9f9 Mon Sep 17 00:00:00 2001
+From d2b63391c770c1601f422ee3d04068ecd4fd8c8d Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 16 Apr 2021 09:01:34 +0300
-Subject: [PATCH 12/44] usb: typec: tcpm: Remove tcpm port reset
+Subject: [PATCH 12/45] usb: typec: tcpm: Remove tcpm port reset
 
 This patch is required to prevent VBUS turning off by the HOST when PD negociation is happening
 
@@ -163,5 +163,5 @@ index 023a36e16bd9..120d33e64544 100644
  
  static int tcpm_port_type_set(struct typec_port *p, enum typec_port_type type)
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0013-drivers-usb-gadget-function-uvc_configfs-Set-guid-to.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0013-drivers-usb-gadget-function-uvc_configfs-Set-guid-to.patch
@@ -1,7 +1,7 @@
-From 8f7e1f87b410b62b7e15303674c36ee505b8388a Mon Sep 17 00:00:00 2001
+From 2a7644d1fc2330231a4e56e543ed0c2519873f1b Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 22 Jun 2021 17:08:26 +0300
-Subject: [PATCH 13/44] drivers: usb: gadget: function: uvc_configfs: Set guid
+Subject: [PATCH 13/45] drivers: usb: gadget: function: uvc_configfs: Set guid
  to "Y16"
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -23,5 +23,5 @@ index 5dec2a126fd2..16ba47ee4d9b 100644
  	};
  	struct uvcg_uncompressed *h;
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0014-arch-arm64-imx8mp-adi-tof-noreg-Activate-pull-down-o.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0014-arch-arm64-imx8mp-adi-tof-noreg-Activate-pull-down-o.patch
@@ -1,7 +1,7 @@
-From 9cd8bac790cc4f452fd05b700fd3009e9d143cc0 Mon Sep 17 00:00:00 2001
+From a962f3519b7076d2215816374765ab39397e982b Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 7 Jul 2021 12:07:54 +0300
-Subject: [PATCH 14/44] arch: arm64: imx8mp-adi-tof-noreg: Activate pull-down
+Subject: [PATCH 14/45] arch: arm64: imx8mp-adi-tof-noreg: Activate pull-down
  on flash WP
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -13,7 +13,7 @@ diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts b/arch/arm64
 index 28924e4bc0f9..06332e91004a 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
-@@ -1111,7 +1111,7 @@
+@@ -1111,7 +1111,7 @@ MX8MP_IOMUXC_ECSPI2_MOSI__GPIO5_IO11		0x100 /* MOSI pin as GPIO with pull-down *
  
  	pinctrl_nvram_gpio: nvram-gpio-grp {
  		fsl,pins = <
@@ -23,5 +23,5 @@ index 28924e4bc0f9..06332e91004a 100644
  	};
  
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0015-drivers-media-spi-addicmos-Add-custom-control-for-co.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0015-drivers-media-spi-addicmos-Add-custom-control-for-co.patch
@@ -1,7 +1,7 @@
-From cd71e84de46caa8d9235f7a551e547707b5d8ee0 Mon Sep 17 00:00:00 2001
+From 918b9fe5a581b5fb15a0fc3fd6c08734edbf3ebf Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 7 Jul 2021 12:08:46 +0300
-Subject: [PATCH 15/44] drivers: media: spi: addicmos: Add custom control for
+Subject: [PATCH 15/45] drivers: media: spi: addicmos: Add custom control for
  config/claib writing
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -142,5 +142,5 @@ index 94a37e3bdd07..14faf522d39f 100644
  	if (ret) {
  		dev_err(dev, "%s: control initialization error %d\n",
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0016-adrivers-media-spi-addicmos.c-Add-resolution-for-mod.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0016-adrivers-media-spi-addicmos.c-Add-resolution-for-mod.patch
@@ -1,7 +1,7 @@
-From 80e36605aa390c5480a033ab95b697151a532023 Mon Sep 17 00:00:00 2001
+From dbb50f7f0ea76d300c49ddb96c0a61b7ac0363b9 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 23 Jul 2021 09:07:30 +0300
-Subject: [PATCH 16/44] adrivers: media: spi: addicmos.c: Add resolution for
+Subject: [PATCH 16/45] adrivers: media: spi: addicmos.c: Add resolution for
  mode 10
 
 Mode 10 require 4096x256x9 subframes so add corresponding resolution. Also disable default writing of calibration data.
@@ -15,14 +15,14 @@ diff --git a/drivers/media/spi/addicmos.c b/drivers/media/spi/addicmos.c
 index 14faf522d39f..24ce8e03988f 100644
 --- a/drivers/media/spi/addicmos.c
 +++ b/drivers/media/spi/addicmos.c
-@@ -150,6 +150,7 @@ static const struct reg_sequence addicmos_standby_setting[] = {
+@@ -154,6 +154,7 @@ static const s64 link_freq_tbl[] = {
+ 	732000000,
+ 	732000000,
+ 	732000000,
++	732000000,
+ 	732000000
  };
  
- static const s64 link_freq_tbl[] = {
-+	732000000,
- 	732000000,
- 	732000000,
- 	732000000,
 @@ -185,9 +186,15 @@ static const struct addicmos_mode_info addicmos_mode_info_data[] = {
  	},
  	{
@@ -52,5 +52,5 @@ index 14faf522d39f..24ce8e03988f 100644
  			addicmos_powerup_setting,
  			ARRAY_SIZE(addicmos_powerup_setting));
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0017-pwm-gpio-Add-a-generic-gpio-based-PWM-driver.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0017-pwm-gpio-Add-a-generic-gpio-based-PWM-driver.patch
@@ -1,7 +1,7 @@
-From 6fcd3183a11959523c1c5d0ababc8dd2063b9ee2 Mon Sep 17 00:00:00 2001
+From 69bb46ef3f40811bff1a360a38bf14fc0b284060 Mon Sep 17 00:00:00 2001
 From: Olliver Schinagl <oliver@schinagl.nl>
 Date: Mon, 26 Oct 2015 22:32:38 +0100
-Subject: [PATCH 17/44] pwm: gpio: Add a generic gpio based PWM driver
+Subject: [PATCH 17/45] pwm: gpio: Add a generic gpio based PWM driver
 
 This patch adds a bit-banging gpio PWM driver. It makes use of hrtimers,
 to allow nano-second resolution, though it obviously strongly depends on
@@ -345,5 +345,5 @@ index 000000000000..7e9ffcc1c547
 +MODULE_DESCRIPTION("Generic GPIO bit-banged PWM driver");
 +MODULE_LICENSE("GPL");
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0018-Add-FSYNC-control-using-PWM-framework.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0018-Add-FSYNC-control-using-PWM-framework.patch
@@ -1,7 +1,7 @@
-From 59e4586f8f7ecf804c080ca0f4a14b12be076e59 Mon Sep 17 00:00:00 2001
+From de686d67db32b90e9161558ced78f847c092be95 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 17 Sep 2021 11:52:08 +0300
-Subject: [PATCH 18/44] Add FSYNC control using PWM framework
+Subject: [PATCH 18/45] Add FSYNC control using PWM framework
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -13,7 +13,7 @@ diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts b/arch/arm64
 index 06332e91004a..a7521545f245 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
-@@ -221,6 +221,12 @@
+@@ -221,6 +221,12 @@ mpcie {
  		status = "okay";
  		enable-active-high;
  	};
@@ -26,7 +26,7 @@ index 06332e91004a..a7521545f245 100644
  };
  
  &clk {
-@@ -452,6 +458,8 @@
+@@ -452,6 +458,8 @@ addicmos@0 {
  		pinctrl-names = "spi", "gpio";
  		pinctrl-0 = <&pinctrl_addicmos_spi>;
  		pinctrl-1 = <&pinctrl_addicmos_gpio>;
@@ -235,5 +235,5 @@ index 24ce8e03988f..66a2bbf48cec 100644
  
  	addicmos->pixel_rate = v4l2_ctrl_new_std(&addicmos->ctrls,
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0019-usb-gadget-Set-lowest-allowed-speed-to-SS.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0019-usb-gadget-Set-lowest-allowed-speed-to-SS.patch
@@ -1,7 +1,7 @@
-From 97115a0405a77b7c22424370ac313261017f869f Mon Sep 17 00:00:00 2001
+From 5fcf2628d00c472fdee8d70afc54c750f1e11fc7 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 7 Oct 2021 16:10:47 +0300
-Subject: [PATCH 19/44] usb: gadget: Set lowest allowed speed to SS
+Subject: [PATCH 19/45] usb: gadget: Set lowest allowed speed to SS
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -27,5 +27,5 @@ index 3ffa939678d7..ca4e3ebf5334 100644
  		ss_cap->bU2DevExitLat = dcd_config_params.bU2DevExitLat;
  	}
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0020-drivers-media-addicmos-Add-module-parameter-to-enabl.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0020-drivers-media-addicmos-Add-module-parameter-to-enabl.patch
@@ -1,7 +1,7 @@
-From 84a96ca9804ecd9ed73b8557febba548e8740710 Mon Sep 17 00:00:00 2001
+From b6e6ba7d41a5246ac0599997a7a2e93c35b32185 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Mon, 8 Nov 2021 11:00:31 +0200
-Subject: [PATCH 20/44] drivers: media: addicmos: Add module parameter to
+Subject: [PATCH 20/45] drivers: media: addicmos: Add module parameter to
  enable FW/Calib loading
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -168,5 +168,5 @@ index 66a2bbf48cec..76039eaa179d 100644
  
  static int addicmos_probe(struct spi_device *client)
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0021-arch-arm64-imx8mp-adi-tof-noreg-Increase-CMA-size.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0021-arch-arm64-imx8mp-adi-tof-noreg-Increase-CMA-size.patch
@@ -1,7 +1,7 @@
-From 30f5b16c17170484089abf9fb63bdaef80d70611 Mon Sep 17 00:00:00 2001
+From aa17897e88ba1822a9046281edc198c21a8b80ab Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Mon, 8 Nov 2021 11:01:37 +0200
-Subject: [PATCH 21/44] arch: arm64: imx8mp-adi-tof-noreg: Increase CMA size
+Subject: [PATCH 21/45] arch: arm64: imx8mp-adi-tof-noreg: Increase CMA size
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -12,7 +12,7 @@ diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts b/arch/arm64
 index a7521545f245..87d81263e6a1 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
-@@ -229,6 +229,16 @@
+@@ -229,6 +229,16 @@ pwm: pwm-gpio {
  	};
  };
  
@@ -30,5 +30,5 @@ index a7521545f245..87d81263e6a1 100644
  	init-on-array = <IMX8MP_CLK_HSIO_ROOT>;
  };
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0022-drivers-media-addicmos.c-Modify-chip_config-ctrl.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0022-drivers-media-addicmos.c-Modify-chip_config-ctrl.patch
@@ -1,7 +1,7 @@
-From d1d969f8f7d704bbeb3feb8eff4ada729b1272c4 Mon Sep 17 00:00:00 2001
+From b4b46a19e446c6d145beb67559829a48bbc4e1d1 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 10 Nov 2021 15:03:13 +0200
-Subject: [PATCH 22/44] drivers: media: addicmos.c: Modify chip_config ctrl
+Subject: [PATCH 22/45] drivers: media: addicmos.c: Modify chip_config ctrl
 
 Modify chip_config ctrl to get through V4L a block of
 addr<->reg values and loop through in driver and not in SDK.
@@ -72,5 +72,5 @@ index 76039eaa179d..cedcde9982e6 100644
  };
  
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0023-drivers-mtd-spi-nor-Add-support-for-MX25U1632F.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0023-drivers-mtd-spi-nor-Add-support-for-MX25U1632F.patch
@@ -1,7 +1,7 @@
-From 95471884a352c1f5e48e23f212225b1d7d7690da Mon Sep 17 00:00:00 2001
+From 1be949fcb78ff2c1dfab58c1a1aa63367e96ba10 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 4 Feb 2022 10:17:58 +0200
-Subject: [PATCH 23/44] drivers: mtd: spi-nor: Add support for MX25U1632F
+Subject: [PATCH 23/45] drivers: mtd: spi-nor: Add support for MX25U1632F
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -21,5 +21,5 @@ index c145a09cecd1..62ba71c0e15d 100644
  			      SECT_4K | SPI_NOR_DUAL_READ |
  			      SPI_NOR_QUAD_READ) },
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0024-drivers-media-spi-addicmos-Fix-resolution-for-QVGA-m.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0024-drivers-media-spi-addicmos-Fix-resolution-for-QVGA-m.patch
@@ -1,7 +1,7 @@
-From 04bef1aafbf5a558fba821aea8b86246a43fe1ce Mon Sep 17 00:00:00 2001
+From 73dd899a2627665665c15f3f78f113752bc00f62 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 8 Feb 2022 11:51:27 +0200
-Subject: [PATCH 24/44] drivers: media: spi: addicmos: Fix resolution for QVGA
+Subject: [PATCH 24/45] drivers: media: spi: addicmos: Fix resolution for QVGA
  mode
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -23,5 +23,5 @@ index cedcde9982e6..1b22f075b845 100644
  		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
  	},
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0025-drivers-media-addicmos-Reduce-line-width-for-QVGA-mo.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0025-drivers-media-addicmos-Reduce-line-width-for-QVGA-mo.patch
@@ -1,7 +1,7 @@
-From 5cd2eb69b65d729d68bc1dac630ff21dddb5f015 Mon Sep 17 00:00:00 2001
+From a3fbcdec6d155146e7e8b9bd9409866886563bf5 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 8 Feb 2022 14:46:37 +0200
-Subject: [PATCH 25/44] drivers: media: addicmos: Reduce line width for QVGA
+Subject: [PATCH 25/45] drivers: media: addicmos: Reduce line width for QVGA
  mode
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -26,5 +26,5 @@ index 1b22f075b845..f93c97e9ee07 100644
  
  	ret = pwm_enable(addicmos->pwm_fsync);
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0026-drivers-staging-media-imx-imx8-media-dev.c-Support-b.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0026-drivers-staging-media-imx-imx8-media-dev.c-Support-b.patch
@@ -1,7 +1,7 @@
-From fa8120d8e68beb91ef31741958ecc2e28c32e48c Mon Sep 17 00:00:00 2001
+From 5c5179bb7c4b3abdad166a12f26159735428ba13 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 5 May 2022 11:49:35 +0300
-Subject: [PATCH 26/44] drivers: staging: media: imx: imx8-media-dev.c: Support
+Subject: [PATCH 26/45] drivers: staging: media: imx: imx8-media-dev.c: Support
  both SPI and I2C
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -36,5 +36,5 @@ index 79812119a341..4dbac8baf1d4 100644
  				  "Can't find spi client device for %s\n",
  				  of_node_full_name(rem));
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0027-drivers-staging-media-imx8-isi-cap.c-Add-RAW8-suppor.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0027-drivers-staging-media-imx8-isi-cap.c-Add-RAW8-suppor.patch
@@ -1,7 +1,7 @@
-From 822b2090d0be64b0098cd502c0bb82e2d0a24abf Mon Sep 17 00:00:00 2001
+From 25024fc7296e0e26f155dbcc806303c296947886 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 6 Jan 2022 13:45:38 +0200
-Subject: [PATCH 27/44] drivers: staging: media: imx8-isi-cap.c: Add RAW8
+Subject: [PATCH 27/45] drivers: staging: media: imx8-isi-cap.c: Add RAW8
  support
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -42,5 +42,5 @@ index 5f02d3280408..8109a9dc35d0 100644
  };
  
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0028-drivers-usb-gadget-function-uvc_v4l2.c-Add-support-f.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0028-drivers-usb-gadget-function-uvc_v4l2.c-Add-support-f.patch
@@ -1,7 +1,7 @@
-From 96a78779a92f40e63e56d609e17429bc8bba0314 Mon Sep 17 00:00:00 2001
+From e184b1c706b0eb2f2a6a1dd2bc895354b175dbdc Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Mon, 28 Feb 2022 11:07:06 +0200
-Subject: [PATCH 28/44] drivers: usb: gadget: function: uvc_v4l2.c: Add support
+Subject: [PATCH 28/45] drivers: usb: gadget: function: uvc_v4l2.c: Add support
  for SBGGR8/16
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -23,5 +23,5 @@ index 4ca89eab6159..19952ef98685 100644
  
  static int
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0029-drivers-staging-media-imx-imx8-Fix-SBGGR8-support.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0029-drivers-staging-media-imx-imx8-Fix-SBGGR8-support.patch
@@ -1,7 +1,7 @@
-From 4263a20b78c9e7b72dd5253aa18c7a1688d93cc3 Mon Sep 17 00:00:00 2001
+From bfeef0364c58cd916d0e35e69ffa65330f8fa0a7 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Mon, 28 Feb 2022 11:08:48 +0200
-Subject: [PATCH 29/44] drivers: staging: media: imx: imx8: Fix SBGGR8 support
+Subject: [PATCH 29/45] drivers: staging: media: imx: imx8: Fix SBGGR8 support
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -85,5 +85,5 @@ index b187fa5f4e09..9d3ffa5b23ce 100644
  	    code = MEDIA_BUS_FMT_SBGGR10_1X10;
  	    break;
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0030-Rename-control-to-ADSD.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0030-Rename-control-to-ADSD.patch
@@ -1,7 +1,7 @@
-From 7a198a3a6496603937b443aaf7466b5b3609b3df Mon Sep 17 00:00:00 2001
+From c87c6ea5c5cf0c16bd11d956c4785d4b1715f0a8 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 5 May 2022 11:48:14 +0300
-Subject: [PATCH 30/44] Rename control to ADSD
+Subject: [PATCH 30/45] Rename control to ADSD
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -22,5 +22,5 @@ index 21e3b433856a..9119621a92fb 100644
  /* MPEG-class control IDs */
  /* The MPEG controls are applicable to all codec controls
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0031-drivers-media-i2c-Initial-revision-of-ADSD3500-drive.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0031-drivers-media-i2c-Initial-revision-of-ADSD3500-drive.patch
@@ -1,7 +1,7 @@
-From 5dbc340f757e92fcf715836f2129137e5c0e378a Mon Sep 17 00:00:00 2001
+From 15b15edee0b184aef441cfd36a62f4f904e25c17 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 3 Nov 2021 16:26:00 +0200
-Subject: [PATCH 31/44] drivers: media: i2c: Initial revision of ADSD3500
+Subject: [PATCH 31/45] drivers: media: i2c: Initial revision of ADSD3500
  driver
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -2334,5 +2334,5 @@ index 000000000000..95f88fe6deff
 +
 +#endif
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0032-drivers-media-spi-addicmos.c-Add-dummy-s_power-to-ke.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0032-drivers-media-spi-addicmos.c-Add-dummy-s_power-to-ke.patch
@@ -1,7 +1,7 @@
-From 6269416b279ab5e49d299611705c4db07604efc6 Mon Sep 17 00:00:00 2001
+From 7474b0a22aaa9cbbb7c811209103a94cb30a522e Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 10 Mar 2022 10:04:43 +0200
-Subject: [PATCH 32/44] drivers: media: spi: addicmos.c: Add dummy s_power to
+Subject: [PATCH 32/45] drivers: media: spi: addicmos.c: Add dummy s_power to
  keep capture driver happy
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -37,5 +37,5 @@ index f93c97e9ee07..b22928807ec7 100644
  
  static const struct dev_pm_ops addicmos_pm_ops = {
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0033-Rename-addicmos-to-adsd3100.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0033-Rename-addicmos-to-adsd3100.patch
@@ -1,7 +1,7 @@
-From 3c767eff89e6f5c50e3b3a61c23a0560111b7086 Mon Sep 17 00:00:00 2001
+From 6b2d764391dfd96ebea83482535e599b28a7b5ff Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 5 May 2022 11:36:40 +0300
-Subject: [PATCH 33/44] Rename addicmos to adsd3100
+Subject: [PATCH 33/45] Rename addicmos to adsd3100
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -18,7 +18,7 @@ diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts b/arch/arm64
 index 87d81263e6a1..e8a81ab5e80d 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
-@@ -85,7 +85,8 @@
+@@ -85,7 +85,8 @@ reg_v5v0: regulator-v5v0 {
  		regulator-max-microvolt = <5000000>;
  		gpio = <&gpio4 30 GPIO_ACTIVE_HIGH>;
  		enable-active-high;
@@ -28,7 +28,7 @@ index 87d81263e6a1..e8a81ab5e80d 100644
  	};
  
  	reg_vmain: regulator-vmain {
-@@ -97,7 +98,7 @@
+@@ -97,7 +98,7 @@ reg_vmain: regulator-vmain {
  		regulator-max-microvolt = <5000000>;
  		gpio = <&gpio5 0 GPIO_ACTIVE_HIGH>;
  		enable-active-high;
@@ -37,7 +37,7 @@ index 87d81263e6a1..e8a81ab5e80d 100644
  	};
  
  	reg_vsys: regulator-vsys {
-@@ -111,7 +112,8 @@
+@@ -111,7 +112,8 @@ reg_vsys: regulator-vsys {
  		gpio = <&gpio5 1 GPIO_ACTIVE_HIGH>;
  		startup-delay-us = <70000>;
  		enable-active-high;
@@ -47,7 +47,7 @@ index 87d81263e6a1..e8a81ab5e80d 100644
  	};
  
  	reg_vaux: regulator-vaux {
-@@ -125,7 +127,8 @@
+@@ -125,7 +127,8 @@ reg_vaux: regulator-vaux {
  		gpio = <&gpio4 31 GPIO_ACTIVE_HIGH>;
  		startup-delay-us = <100000>;
  		enable-active-high;
@@ -57,7 +57,7 @@ index 87d81263e6a1..e8a81ab5e80d 100644
  	};
  
  	reg_vcc_3p3: regulator-vcc-3p3 {
-@@ -139,7 +142,7 @@
+@@ -139,7 +142,7 @@ reg_vcc_3p3: regulator-vcc-3p3 {
  		startup-delay-us = <7000>;
  		enable-active-high;
  		regulator-always-on;
@@ -66,7 +66,7 @@ index 87d81263e6a1..e8a81ab5e80d 100644
  	};
  
  	reg_can1_stby: regulator-can1-stby {
-@@ -443,7 +446,7 @@
+@@ -443,7 +446,7 @@ &mipi_csi_0 {
  	port@0 {
  		reg = <0>;
  		mipi_csi0_ep: endpoint {
@@ -75,7 +75,7 @@ index 87d81263e6a1..e8a81ab5e80d 100644
  			data-lanes = <4>;
  			csis-hs-settle = <32>;
  			csis-clk-settle = <0>;
-@@ -458,21 +461,21 @@
+@@ -458,21 +461,21 @@ &ecspi2 {
  	cs-gpios = <&gpio5 13 GPIO_ACTIVE_LOW>, <&gpio3 9 GPIO_ACTIVE_LOW>;
  	status = "okay";
  
@@ -102,7 +102,7 @@ index 87d81263e6a1..e8a81ab5e80d 100644
  				remote-endpoint = <&mipi_csi0_ep>;
  				data-lanes = <1 2 3 4>;
  				clock-lanes = <0>;
-@@ -717,6 +720,8 @@
+@@ -717,6 +720,8 @@ &usdhc1 {
  	vmmc-supply = <&reg_sd1_vmmc>;
  	reset-gpio = <&gpio2 11 GPIO_ACTIVE_LOW>;
  	status = "okay";
@@ -111,7 +111,7 @@ index 87d81263e6a1..e8a81ab5e80d 100644
  	brcmf: brcmf@1 {
  		reg = <1>;
  		compatible = "brcm,bcm4329-fmac";
-@@ -1115,13 +1120,13 @@
+@@ -1115,13 +1120,13 @@ MX8MP_IOMUXC_ECSPI2_MISO__ECSPI2_MISO		0x82 /* MISO: spi master-in-slave-out */
  		>;
  	};
  
@@ -2414,5 +2414,5 @@ index 000000000000..2c04599266e0
 +MODULE_AUTHOR("Bogdan Togorean");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0034-drivers-staging-media-Add-support-for-RAW16.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0034-drivers-staging-media-Add-support-for-RAW16.patch
@@ -1,7 +1,7 @@
-From c98dd0b9175a6eecbc9db5c7c74a97c025a3e30a Mon Sep 17 00:00:00 2001
+From e7ff8742cbdcabfec4d210dd121229542c0b8d5d Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 19 May 2022 11:54:21 +0300
-Subject: [PATCH 34/44] drivers/staging/media: Add support for RAW16
+Subject: [PATCH 34/45] drivers/staging/media: Add support for RAW16
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -120,5 +120,5 @@ index 132768c03f41..e95ae0ab7525 100644
  		index = 0;
  	return &mxc_isi_src_formats[index];
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0035-drivers-media-i2c-adsd3500-Fix-MP-frames-width-and-h.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0035-drivers-media-i2c-adsd3500-Fix-MP-frames-width-and-h.patch
@@ -1,7 +1,7 @@
-From 6b6e67a0301c788d205801afa57e32535aa7796d Mon Sep 17 00:00:00 2001
+From 275414afd7f22a90cd5ef02a10bc76ac27749730 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Mon, 23 May 2022 15:55:13 +0300
-Subject: [PATCH 35/44] drivers: media: i2c: adsd3500: Fix MP frames width and
+Subject: [PATCH 35/45] drivers: media: i2c: adsd3500: Fix MP frames width and
  height
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -13,15 +13,13 @@ diff --git a/drivers/media/i2c/adsd3500.c b/drivers/media/i2c/adsd3500.c
 index e3a67a793e51..358a68fa47d6 100644
 --- a/drivers/media/i2c/adsd3500.c
 +++ b/drivers/media/i2c/adsd3500.c
-@@ -87,6 +87,7 @@ static const struct reg_sequence adsd3500_standby_setting[] = {
- };
- 
- static const s64 link_freq_tbl[] = {
+@@ -98,16 +98,17 @@ static const s64 link_freq_tbl[] = {
+ 	732000000,
+ 	732000000,
+ 	732000000,
 +	732000000,
- 	732000000,
- 	732000000,
- 	732000000,
-@@ -103,11 +104,11 @@ static const s64 link_freq_tbl[] = {
+ 	732000000
+ };
  
  /* Elements of the structure must be ordered ascending by width & height */
  static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
@@ -87,5 +85,5 @@ index e3a67a793e51..358a68fa47d6 100644
  };
  
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0036-media-i2c-adsd3500-Implement-SET-GET-framerate-contr.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0036-media-i2c-adsd3500-Implement-SET-GET-framerate-contr.patch
@@ -1,7 +1,7 @@
-From 06f16e2e376f248c63c21cfc04f3e92d9db1d642 Mon Sep 17 00:00:00 2001
+From e31d75deaca4e4de5ae997af9daa58da987e9e35 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 13 Jul 2022 10:54:29 +0300
-Subject: [PATCH 36/44] media: i2c: adsd3500: Implement SET/GET framerate
+Subject: [PATCH 36/45] media: i2c: adsd3500: Implement SET/GET framerate
  control
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -65,5 +65,5 @@ index 358a68fa47d6..c498ec7857d1 100644
  
  static int adsd3500_link_setup(struct media_entity *entity,
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0037-drivers-media-adsd-Remove-duplicate-link_freqs.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0037-drivers-media-adsd-Remove-duplicate-link_freqs.patch
@@ -1,7 +1,7 @@
-From e7956d771e6f966e421e6005bf999d6360950862 Mon Sep 17 00:00:00 2001
+From dc0d067cd78339c27d839058d064307957eda938 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 2 Aug 2022 17:12:18 +0300
-Subject: [PATCH 37/44] drivers: media: adsd: Remove duplicate link_freqs
+Subject: [PATCH 37/45] drivers: media: adsd: Remove duplicate link_freqs
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -183,5 +183,5 @@ index 2c04599266e0..d2cc706e0b5d 100644
  };
  
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0038-drivers-media-adsd3500-Add-AB-test-resolution-suppor.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0038-drivers-media-adsd3500-Add-AB-test-resolution-suppor.patch
@@ -1,7 +1,7 @@
-From 6d8a18f7be5c14836d1bc06c02c76d15f853a267 Mon Sep 17 00:00:00 2001
+From 81bfba423f281026d269bf0ab81b159fa2f4cb57 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 17 Aug 2022 09:58:58 +0300
-Subject: [PATCH 38/44] drivers: media: adsd3500: Add AB test resolution
+Subject: [PATCH 38/45] drivers: media: adsd3500: Add AB test resolution
  support
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -28,5 +28,5 @@ index 22e7f5e11f86..5668975bc436 100644
  		.width = 1024,
  		.height = 1024,
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0039-drivers-media-adsd3100-Revert-adsd3100-to-YUYV.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0039-drivers-media-adsd3100-Revert-adsd3100-to-YUYV.patch
@@ -1,7 +1,7 @@
-From fbe2c9fb8b119a43d9fed40b0569b5ed6fbe3d0a Mon Sep 17 00:00:00 2001
+From 99ff3626e2fe71520db79399a8a7f46cc825c3c4 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 17 Aug 2022 10:04:07 +0300
-Subject: [PATCH 39/44] drivers: media: adsd3100: Revert adsd3100 to YUYV
+Subject: [PATCH 39/45] drivers: media: adsd3100: Revert adsd3100 to YUYV
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -87,5 +87,5 @@ index e95ae0ab7525..667eaa473638 100644
  		.name		= "ADI_RAW16 (CUSTOM)",
  		.fourcc		= V4L2_PIX_FMT_SBGGR16,
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0040-arch-arm64-imx8mp-adi-tof-adsd3500.dts-Disable-1P8-a.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0040-arch-arm64-imx8mp-adi-tof-adsd3500.dts-Disable-1P8-a.patch
@@ -1,7 +1,7 @@
-From 5ea22e74ad4084d7f7fad0c81c6f2894fd3554ce Mon Sep 17 00:00:00 2001
+From 896799a0aa09f476bbd83c041dd426d5ca770a21 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 17 Aug 2022 10:14:34 +0300
-Subject: [PATCH 40/44] arch: arm64: imx8mp-adi-tof-adsd3500.dts: Disable 1P8
+Subject: [PATCH 40/45] arch: arm64: imx8mp-adi-tof-adsd3500.dts: Disable 1P8
  and 0P8 reg
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -13,7 +13,7 @@ diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3500.dts b/arch/ar
 index e8c04e913ec9..9cd1d65b02b3 100644
 --- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3500.dts
 +++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3500.dts
-@@ -112,22 +112,20 @@
+@@ -112,22 +112,20 @@ reg_vdd_0p8: regulator-vdd-0p8 {
  		gpio = <&gpio_exp_1 7 GPIO_ACTIVE_HIGH>;
  		startup-delay-us = <100000>;
  		enable-active-high;
@@ -39,5 +39,5 @@ index e8c04e913ec9..9cd1d65b02b3 100644
  	};
  
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0041-drivers-media-i2c-adsd3500-Add-ADSD30303-resolutions.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0041-drivers-media-i2c-adsd3500-Add-ADSD30303-resolutions.patch
@@ -1,7 +1,7 @@
-From 198150207319e5d53c355a751e162cc0405b44fd Mon Sep 17 00:00:00 2001
+From c8d8865fa8b9d2b54f6e760f2e068d7119fe46ae Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 23 Aug 2022 16:39:27 +0300
-Subject: [PATCH 41/44] drivers: media: i2c: adsd3500: Add ADSD30303
+Subject: [PATCH 41/45] drivers: media: i2c: adsd3500: Add ADSD30303
  resolutions
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -49,5 +49,5 @@ index 5668975bc436..e6931320a871 100644
  		.width = 1024,
  		.height = 1024,
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0042-drivers-media-common-v4l2-loopback-Add-v4l2-loopback.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0042-drivers-media-common-v4l2-loopback-Add-v4l2-loopback.patch
@@ -1,7 +1,7 @@
-From 907c35d87b07a4fa471ab9112321788be6e7f76e Mon Sep 17 00:00:00 2001
+From b733d15ef79f74df4703c8a1c858fbe380d479d3 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 29 Sep 2022 13:27:06 +0300
-Subject: [PATCH 42/44] drivers: media: common: v4l2-loopback: Add
+Subject: [PATCH 42/45] drivers: media: common: v4l2-loopback: Add
  v4l2-loopback driver
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
@@ -3578,5 +3578,5 @@ index 000000000000..d855a3796554
 +#endif /* V4L2_PIX_FMT_HEVC */
 +};
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0043-drivers-media-spi-adsd3100-Add-1-pase-mode.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0043-drivers-media-spi-adsd3100-Add-1-pase-mode.patch
@@ -1,7 +1,7 @@
-From c0e19b2f71d66c5c5fb5238a06e081e709789f1f Mon Sep 17 00:00:00 2001
+From e1e02886a4db741039bb1a5e36ec70faa43b8804 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 29 Sep 2022 13:32:58 +0300
-Subject: [PATCH 43/44] drivers: media: spi: adsd3100: Add 1 pase mode
+Subject: [PATCH 43/45] drivers: media: spi: adsd3100: Add 1 pase mode
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -26,5 +26,5 @@ index da5b9fe9b961..d2177194dc47 100644
  		.width = 4096,
  		.height = 256,
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0044-drivers-staging-media-imx-Fix-YUYV-mode.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0044-drivers-staging-media-imx-Fix-YUYV-mode.patch
@@ -1,7 +1,7 @@
-From feefb83e7ef96a1c11ac5f91b17a10af9e139326 Mon Sep 17 00:00:00 2001
+From eeaaf0db1a28fe945caaffb0d15d9a269713328a Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 29 Sep 2022 13:35:04 +0300
-Subject: [PATCH 44/44] drivers: staging: media: imx: Fix YUYV mode
+Subject: [PATCH 44/45] drivers: staging: media: imx: Fix YUYV mode
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
@@ -66,5 +66,5 @@ index 9d3ffa5b23ce..6741ebc50632 100644
  		break;
  	case MEDIA_BUS_FMT_SGBRG12_1X12:
 -- 
-2.17.1
+2.38.1
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0045-drivers-media-i2c-adsd3500-Add-adsd3030-support.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0045-drivers-media-i2c-adsd3500-Add-adsd3030-support.patch
@@ -1,35 +1,35 @@
-From 30a732a9b88473a43cb9f93e7a798aa60a8341b0 Mon Sep 17 00:00:00 2001
+From 32e7a7c9563b0593ece46ca4400150b13ea2a009 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
-Date: Fri, 16 Apr 2021 09:03:47 +0300
-Subject: [PATCH 06/45] arch: arm64: dts: ADI TOF dt
+Date: Wed, 9 Nov 2022 14:39:43 +0200
+Subject: [PATCH 45/45] drivers: media: i2c: adsd3500: Add adsd3030 support
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---
- arch/arm64/boot/dts/freescale/Makefile        |    3 +-
- .../dts/freescale/imx8mp-adi-tof-noreg.dts    | 1199 +++++++++++++++++
- 2 files changed, 1201 insertions(+), 1 deletion(-)
- create mode 100644 arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
+ arch/arm64/boot/dts/freescale/Makefile        |    2 +-
+ .../dts/freescale/imx8mp-adi-tof-adsd3030.dts | 1183 +++++++++++++++++
+ drivers/media/i2c/adsd3500.c                  |   35 +-
+ 3 files changed, 1212 insertions(+), 8 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3030.dts
 
 diff --git a/arch/arm64/boot/dts/freescale/Makefile b/arch/arm64/boot/dts/freescale/Makefile
-index 49642e6f35b5..45eb94278be2 100644
+index 250cd1e0cd9d..bb0f9e828717 100644
 --- a/arch/arm64/boot/dts/freescale/Makefile
 +++ b/arch/arm64/boot/dts/freescale/Makefile
-@@ -102,7 +102,8 @@ dtb-$(CONFIG_ARCH_MXC) += imx8mp-evk.dtb imx8mp-evk-rm67191.dtb imx8mp-evk-it626
- 			  imx8mp-evk-dual-ov2775.dtb imx8mp-evk-spdif-lb.dtb \
+@@ -103,7 +103,7 @@ dtb-$(CONFIG_ARCH_MXC) += imx8mp-evk.dtb imx8mp-evk-rm67191.dtb imx8mp-evk-it626
  			  imx8mp-evk-sof-wm8960.dtb imx8mp-evk-dsp.dtb\
  			  imx8mp-evk-iqaudio-dacplus.dtb imx8mp-evk-iqaudio-dacpro.dtb imx8mp-evk-hifiberry-dacplus.dtb \
--			  imx8mp-evk-usdhc1-m2.dtb imx8mp-evk-rm67199.dtb
-+			  imx8mp-evk-usdhc1-m2.dtb imx8mp-evk-rm67199.dtb \
-+			  imx8mp-adi-tof-noreg.dtb
+ 			  imx8mp-evk-usdhc1-m2.dtb imx8mp-evk-rm67199.dtb \
+-			  imx8mp-adi-tof-noreg.dtb imx8mp-adi-tof-adsd3500.dtb
++			  imx8mp-adi-tof-noreg.dtb imx8mp-adi-tof-adsd3500.dtb imx8mp-adi-tof-adsd3030.dtb
  dtb-$(CONFIG_ARCH_MXC) += imx8mq-evk.dtb imx8mq-evk-rpmsg.dtb imx8mp-ab2.dtb
  dtb-$(CONFIG_ARCH_MXC) += imx8mp-ddr4-evk.dtb
  dtb-$(CONFIG_ARCH_MXC) += imx8mp-evk-ndm.dtb
-diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3030.dts b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3030.dts
 new file mode 100644
-index 000000000000..ae0e5bb9eeae
+index 000000000000..603ccf4a3b04
 --- /dev/null
-+++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
-@@ -0,0 +1,1199 @@
++++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3030.dts
+@@ -0,0 +1,1183 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright 2019 NXP
@@ -42,7 +42,7 @@ index 000000000000..ae0e5bb9eeae
 +#include "imx8mp.dtsi"
 +
 +/ {
-+	model = "NXP i.MX8MPlus ADI TOF board";
++	model = "NXP i.MX8MPlus ADI TOF carrier + ADSD3030";
 +	compatible = "fsl,imx8mp-solidrun", "fsl,imx8mp";
 +
 +	reserved-memory {
@@ -117,7 +117,8 @@ index 000000000000..ae0e5bb9eeae
 +		regulator-max-microvolt = <5000000>;
 +		gpio = <&gpio4 30 GPIO_ACTIVE_HIGH>;
 +		enable-active-high;
-+		status = "disabled";
++		status = "okay";
++		regulator-always-on;
 +	};
 +
 +	reg_vmain: regulator-vmain {
@@ -129,7 +130,7 @@ index 000000000000..ae0e5bb9eeae
 +		regulator-max-microvolt = <5000000>;
 +		gpio = <&gpio5 0 GPIO_ACTIVE_HIGH>;
 +		enable-active-high;
-+		status = "disabled";
++		status = "okay";
 +	};
 +
 +	reg_vsys: regulator-vsys {
@@ -143,7 +144,8 @@ index 000000000000..ae0e5bb9eeae
 +		gpio = <&gpio5 1 GPIO_ACTIVE_HIGH>;
 +		startup-delay-us = <70000>;
 +		enable-active-high;
-+		status = "disabled";
++		status = "okay";
++		regulator-always-on;
 +	};
 +
 +	reg_vaux: regulator-vaux {
@@ -157,7 +159,8 @@ index 000000000000..ae0e5bb9eeae
 +		gpio = <&gpio4 31 GPIO_ACTIVE_HIGH>;
 +		startup-delay-us = <100000>;
 +		enable-active-high;
-+		status = "disabled";
++		status = "okay";
++		regulator-always-on;
 +	};
 +
 +	reg_vcc_3p3: regulator-vcc-3p3 {
@@ -171,7 +174,7 @@ index 000000000000..ae0e5bb9eeae
 +		startup-delay-us = <7000>;
 +		enable-active-high;
 +		regulator-always-on;
-+		status = "disabled";
++		status = "okay";
 +	};
 +
 +	reg_can1_stby: regulator-can1-stby {
@@ -247,12 +250,22 @@ index 000000000000..ae0e5bb9eeae
 +
 +	mpcie {
 +		pinctrl-names = "default";
-+                pinctrl-0 = <&pinctrl_mpcie>;
++		pinctrl-0 = <&pinctrl_mpcie>;
 +		gpio-0 = <&gpio1 1 GPIO_ACTIVE_HIGH>;
 +		gpio-1 = <&gpio1 5 GPIO_ACTIVE_HIGH>;
 +		status = "okay";
 +		enable-active-high;
 +	};
++};
++
++&resmem {
++	linux,cma {
++			compatible = "shared-dma-pool";
++			reusable;
++			size = <0 0x20000000>;
++			alloc-ranges = <0 0x40000000 0 0xC0000000>;
++			linux,cma-default;
++		};
 +};
 +
 +&clk {
@@ -262,7 +275,7 @@ index 000000000000..ae0e5bb9eeae
 +&pwm4 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&pinctrl_pwm4>;
-+	status = "okay";
++	status = "disabled";
 +};
 +
 +&snvs_rtc{
@@ -271,23 +284,23 @@ index 000000000000..ae0e5bb9eeae
 +
 +/*eth0*/
 +&eqos {
-+        pinctrl-names = "default";
-+        pinctrl-0 = <&pinctrl_eqos>;
-+        phy-mode = "rgmii-id";
-+        phy-handle = <&ethphy0>;
-+        status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_eqos>;
++	phy-mode = "rgmii-id";
++	phy-handle = <&ethphy0>;
++	status = "okay";
 +
-+        mdio {
-+                compatible = "snps,dwmac-mdio";
-+                #address-cells = <1>;
-+                #size-cells = <0>;
++	mdio {
++		compatible = "snps,dwmac-mdio";
++		#address-cells = <1>;
++		#size-cells = <0>;
 +
-+                ethphy0: ethernet-phy@0 {
-+                        compatible = "ethernet-phy-ieee802.3-c22";
-+                        reg = <0>;
-+                        eee-broken-1000t;
-+                };
-+        };
++		ethphy0: ethernet-phy@0 {
++			compatible = "ethernet-phy-ieee802.3-c22";
++			reg = <0>;
++			eee-broken-1000t;
++		};
++	};
 +};
 +
 +&i2c1 {
@@ -297,10 +310,10 @@ index 000000000000..ae0e5bb9eeae
 +	status = "okay";
 +
 +	eeprom: eeprom@50{
-+                compatible = "st,24c02", "atmel,24c02";
-+                reg = <0x50>;
-+                pagesize = <16>;
-+        };
++		compatible = "st,24c02", "atmel,24c02";
++		reg = <0x50>;
++		pagesize = <16>;
++	};
 +
 +	pmic: pca9450@25 {
 +		reg = <0x25>;
@@ -402,52 +415,48 @@ index 000000000000..ae0e5bb9eeae
 +	pinctrl-0 = <&pinctrl_i2c2>;
 +	status = "okay";
 +
-+	ad5593r@10 {
-+		compatible = "adi,ad5593r";
-+		#size-cells = <0>;
-+		#address-cells = <1>;
-+		reg = <0x10>;
++	adsd3500@38 {
++		compatible = "adi,adsd3500";
++		reg = <0x38>;
++		reset-gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
++		port {
++			adsd3500_ep: endpoint {
++				remote-endpoint = <&mipi_csi0_ep>;
++				data-lanes = <1 2>;
++				clock-lanes = <0>;
++				link-frequencies = /bits/ 64 <732000000>;
++			};
++		};
++	};
 +
-+		channel@0 {
-+			reg = <0>;
-+			adi,mode = <CH_MODE_DAC>;
-+			adi,off-state = <CH_OFFSTATE_OUT_TRISTATE>;
-+		};
-+		channel@1 {
-+			reg = <1>;
-+			adi,mode = <CH_MODE_DAC>;
-+			adi,off-state = <CH_OFFSTATE_OUT_TRISTATE>;
-+		};
-+		channel@2 {
-+			reg = <2>;
-+			adi,mode = <CH_MODE_DAC>;
-+			adi,off-state = <CH_OFFSTATE_OUT_TRISTATE>;
-+		};
-+		channel@3 {
-+			reg = <3>;
-+			adi,mode = <CH_MODE_ADC>;
-+			adi,off-state = <CH_OFFSTATE_OUT_TRISTATE>;
-+		};
-+		channel@4 {
-+			reg = <4>;
-+			adi,mode = <CH_MODE_ADC>;
-+			adi,off-state = <CH_OFFSTATE_OUT_TRISTATE>;
-+		};
-+		channel@5 {
-+			reg = <5>;
-+			adi,mode = <CH_MODE_ADC>;
-+			adi,off-state = <CH_OFFSTATE_OUT_TRISTATE>;
-+		};
-+		channel@6 {
-+			reg = <6>;
-+			adi,mode = <CH_MODE_ADC>;
-+			adi,off-state = <CH_OFFSTATE_OUT_TRISTATE>;
-+		};
-+		channel@7 {
-+			reg = <7>;
-+			adi,mode = <CH_MODE_ADC>;
-+			adi,off-state = <CH_OFFSTATE_OUT_TRISTATE>;
-+		};
++	gpio_exp_1: gpio@58 {
++		compatible = "maxim,max7320";
++		reg = <0x58>;
++		vcc-supply = <&reg_v5v0>;
++		gpio-controller;
++		#gpio-cells = <2>;
++		gpio-line-names = "ENB_3V3", "ENB_1V2", "ENB_1V8", "ENB_VLDD",
++				  "ENB_AVDD", "ENB_0V8", "SHDWN_SEL", "DUMMY0";
++	};
++
++	gpio_exp_2: gpio@68 {
++		compatible = "maxim,max7321";
++		reg = <0x68>;
++		vcc-supply = <&reg_v5v0>;
++		gpio-controller;
++		#gpio-cells = <2>;
++		gpio-line-names = "OC0", "OC1", "OC2", "OC3",
++				  "OC4", "OC5", "OC6", "OC7";
++	};
++
++	gpio_exp_3: gpio@6d {
++		compatible = "maxim,max7321";
++		reg = <0x6d>;
++		vcc-supply = <&reg_v5v0>;
++		gpio-controller;
++		#gpio-cells = <2>;
++		gpio-line-names = "M0", "M1", "SI0", "IDSEL",
++				  "U0", "DS2", "U1", "DUMMY0";
 +	};
 +};
 +
@@ -459,8 +468,8 @@ index 000000000000..ae0e5bb9eeae
 +	port@0 {
 +		reg = <0>;
 +		mipi_csi0_ep: endpoint {
-+			remote-endpoint = <&addicmos_ep>;
-+			data-lanes = <4>;
++			remote-endpoint = <&adsd3500_ep>;
++			data-lanes = <2>;
 +			csis-hs-settle = <32>;
 +			csis-clk-settle = <0>;
 +			csis-wclk;
@@ -469,30 +478,9 @@ index 000000000000..ae0e5bb9eeae
 +};
 +
 +&ecspi2 {
-+	cs-gpios = <&gpio5 13 GPIO_ACTIVE_LOW>;
-+	status = "okay";
-+	spi-cpol;
-+	spi-cpha;
-+
-+	addicmos@0 {
-+		compatible = "adi,addicmos";
-+		reg = <0x0>;
-+		spi-max-frequency = <16000000>;
-+
-+		reset-gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
-+		pinctrl-names = "spi", "gpio";
-+		pinctrl-0 = <&pinctrl_ecspi2>;
-+		pinctrl-1 = <&pinctrl_ecspi2_gpio>;
-+
-+		port {
-+			addicmos_ep: endpoint {
-+				remote-endpoint = <&mipi_csi0_ep>;
-+				data-lanes = <1 2 3 4>;
-+				clock-lanes = <0>;
-+				link-frequencies = /bits/ 64 <732000000>;
-+			};
-+		};
-+	};
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_ecspi2>;
++	status = "disabled";
 +};
 +
 +&isp_0 {
@@ -531,9 +519,9 @@ index 000000000000..ae0e5bb9eeae
 +			compatible = "usb-c-connector";
 +			label = "USB-C";
 +			power-role = "sink";
-+			data-role = "dual";
++			data-role = "device";
 +			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
-+						 PDO_VAR(5000, 12000, 3000)>;
++						 PDO_VAR(5000, 20000, 3000)>;
 +			op-sink-microwatt = <15000000>;
 +
 +			ports {
@@ -718,6 +706,8 @@ index 000000000000..ae0e5bb9eeae
 +	vmmc-supply = <&reg_sd1_vmmc>;
 +	reset-gpio = <&gpio2 11 GPIO_ACTIVE_LOW>;
 +	status = "okay";
++	#address-cells = <1>;
++	#size-cells = <0>;
 +	brcmf: brcmf@1 {
 +		reg = <1>;
 +		compatible = "brcm,bcm4329-fmac";
@@ -744,7 +734,7 @@ index 000000000000..ae0e5bb9eeae
 +	pinctrl-2 = <&pinctrl_usdhc3_200mhz>;
 +	bus-width = <8>;
 +	non-removable;
-+	status = "disabled";
++	status = "okay";
 +};
 +
 +&wdog1 {
@@ -1109,16 +1099,10 @@ index 000000000000..ae0e5bb9eeae
 +
 +	pinctrl_ecspi2: ecspi2grp {
 +		fsl,pins = <
-+			MX8MP_IOMUXC_ECSPI2_SS0__GPIO5_IO13		0x140 /* CS: spi chip-select */
-+			MX8MP_IOMUXC_ECSPI2_SCLK__ECSPI2_SCLK		0x82 /* SCK: spi clock */
-+			MX8MP_IOMUXC_ECSPI2_MISO__ECSPI2_MISO		0x82 /* MISO: spi master-in-slave-out */
-+			MX8MP_IOMUXC_ECSPI2_MOSI__ECSPI2_MOSI		0x82 /* MOSI: spi master-out-slave-in */
-+		>;
-+	};
-+
-+	pinctrl_ecspi2_gpio: ecspi2-gpio-grp {
-+		fsl,pins = <
-+			MX8MP_IOMUXC_ECSPI2_MOSI__GPIO5_IO11		0x100 /* MOSI pin as GPIO with pull-down */
++			MX8MP_IOMUXC_ECSPI2_SS0__GPIO5_IO13		0x82 /* ADICMOS CS */
++			MX8MP_IOMUXC_NAND_DATA03__GPIO3_IO09		0x82 /* ADICMOS NVRAM CS */
++			MX8MP_IOMUXC_ECSPI2_SCLK__ECSPI2_SCLK		0x82 /* SCK: SPI clock */
++			MX8MP_IOMUXC_ECSPI2_MISO__ECSPI2_MISO		0x82 /* MISO: SPI master-in-slave-out */
 +		>;
 +	};
 +
@@ -1229,6 +1213,72 @@ index 000000000000..ae0e5bb9eeae
 +&dsp {
 +	status = "okay";
 +};
+\ No newline at end of file
+diff --git a/drivers/media/i2c/adsd3500.c b/drivers/media/i2c/adsd3500.c
+index e6931320a871..b6a7892bb34c 100644
+--- a/drivers/media/i2c/adsd3500.c
++++ b/drivers/media/i2c/adsd3500.c
+@@ -190,6 +190,13 @@ static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
+ 		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
++	{ //RAW8 40BPP ADSD3030
++		.width = 2560,
++		.height = 640,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
++		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
++	},
+ 	{ //RAW12 1 Phase / Frame
+ 		.width = 1024,
+ 		.height = 1024,
+@@ -197,25 +204,39 @@ static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
+ 		.code = MEDIA_BUS_FMT_SBGGR12_1X12,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW12 12BPP * 3 phase
++	{ //RAW12 12BPP ADSD3030
++		.width = 512,
++		.height = 640,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_Y12_1X12,
++		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
++	},
++	{ //RAW12 12BPP * 3 subframes ADSD3030 512x640x3
+ 		.width = 1024,
+-		.height = 3072,
++		.height = 960,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR12_1X12,
++		.code = MEDIA_BUS_FMT_Y12_1X12,
++		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
++	},
++	{ //RAW12 12BPP * 9 subframes ADSD3030 512x640x9
++		.width = 1024,
++		.height = 2880,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_Y12_1X12,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+ 	{ //RAW12 12BPP * 3 phase
+ 		.width = 1024,
+-		.height = 4096,
++		.height = 3072,
+ 		.pixel_rate = 488000000,
+ 		.code = MEDIA_BUS_FMT_SBGGR12_1X12,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW16 16BPP * 3 phase
++	{ //RAW12 12BPP * 3 phase
+ 		.width = 1024,
+-		.height = 3072,
++		.height = 4096,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
++		.code = MEDIA_BUS_FMT_SBGGR12_1X12,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	}
+ };
 -- 
 2.38.1
 

--- a/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/usr/share/systemd/tof-power-en.sh
+++ b/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/usr/share/systemd/tof-power-en.sh
@@ -74,6 +74,91 @@ if [[ $BOARD == "NXP i.MX8MPlus ADI TOF carrier + ADSD3500" ]]; then
 	echo 1 > /sys/class/gpio/gpio122/value
 fi
 
+if [[ $BOARD == "NXP i.MX8MPlus ADI TOF carrier + ADSD3030" ]]; then
+	#ADSD3500 Reset Pin
+	echo 122 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio122/direction
+	echo 0 > /sys/class/gpio/gpio122/value
+
+#U13	#U0 1 - INTERPOSER FLASH / 0 - TEMBIN FLASH
+	echo 492 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio492/direction
+	echo 0 > /sys/class/gpio/gpio492/value
+
+#U5		#EN_AVDD
+	echo 508 > /sys/class/gpio/export
+	echo 1 > /sys/class/gpio/gpio508/value
+
+#U12	#OC0
+	echo 496 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio496/direction
+	echo 0 > /sys/class/gpio/gpio496/value
+
+#U12	#OC1
+	echo 497 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio497/direction
+	echo 0 > /sys/class/gpio/gpio497/value
+
+#U12	#OC2
+	echo 498 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio498/direction
+	echo 0 > /sys/class/gpio/gpio498/value
+
+#U12	#OC3
+	echo 499 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio499/direction
+	echo 0 > /sys/class/gpio/gpio499/value
+
+#U12	#OC4
+	echo 500 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio500/direction
+	echo 0 > /sys/class/gpio/gpio500/value
+
+#U12	#OC5
+	echo 501 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio501/direction
+	echo 0 > /sys/class/gpio/gpio501/value
+
+#U12	#OC6
+	echo 502 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio502/direction
+	echo 0 > /sys/class/gpio/gpio502/value
+
+#U12	#FLASH_WP
+	echo 503 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio503/direction
+	echo 1 > /sys/class/gpio/gpio503/value
+
+
+#U13	#DS2_ON
+	echo 493 > /sys/class/gpio/export
+	echo out > /sys/class/gpio/gpio493/direction
+	echo 0 > /sys/class/gpio/gpio493/value
+
+#U5	#EN_3V3
+	echo 504 > /sys/class/gpio/export
+	echo 1 > /sys/class/gpio/gpio504/value
+
+#U5	#EN_1V2
+	echo 505 > /sys/class/gpio/export
+	echo 1 > /sys/class/gpio/gpio505/value
+
+#U5	#EN_1V8
+	echo 506 > /sys/class/gpio/export
+	echo 1 > /sys/class/gpio/gpio506/value
+
+#U5	#EN_VLDD
+	echo 507 > /sys/class/gpio/export
+	echo 1 > /sys/class/gpio/gpio507/value
+
+#U5	#EN_0V8
+	echo 509 > /sys/class/gpio/export
+	echo 1 > /sys/class/gpio/gpio509/value
+
+	# Pull reset high
+	echo 1 > /sys/class/gpio/gpio122/value
+fi
+
 # Deassert ADC reset - will pop on /dev/i2c1 address 0x10
 echo 132 > /sys/class/gpio/export
 echo out > /sys/class/gpio/gpio132/direction
@@ -89,11 +174,6 @@ i2cset -y 2 0x10 0x10 0x008a w # Vsys = 4.3V
 #i2cset -y 2 0x10 0x11 0x0091 w # Vaux = 27V
 i2cset -y 2 0x10 0x11 0x0594 w # Vaux = 22V
 i2cset -y 2 0x10 0x12 0x00a3 w # V5v0 = 4.7V
-
-# VDAC (3.3v / 1.8v IOs)
-echo 130 > /sys/class/gpio/export
-echo out > /sys/class/gpio/gpio130/direction
-echo 1 > /sys/class/gpio/gpio130/value
 
 i2cset -y 2 0x10 0x04 0xff00 w; i2cset -y 2 0x10 0x02 0xff03 w
 for i in {0..8}; do 

--- a/sdcard-images-utils/nxp/runme.sh
+++ b/sdcard-images-utils/nxp/runme.sh
@@ -145,6 +145,14 @@ if [[ $BUILD_TYPE == "buildroot" ]]; then
 else
 	echo "        append root=/dev/mmcblk1p2 rootwait ro init=/usr/lib/init_resize.sh" >> $ROOTDIR/images/extlinux.conf
 fi
+echo "label ADSD3030" >> $ROOTDIR/images/extlinux.conf
+echo "        linux ../Image" >> $ROOTDIR/images/extlinux.conf
+echo "        fdt ../imx8mp-adi-tof-adsd3030.dtb" >> $ROOTDIR/images/extlinux.conf
+if [[ $BUILD_TYPE == "buildroot" ]]; then
+	echo "        initrd ../rootfs.cpio.uboot" >> $ROOTDIR/images/extlinux.conf
+else
+	echo "        append root=/dev/mmcblk1p2 rootwait ro init=/usr/lib/init_resize.sh" >> $ROOTDIR/images/extlinux.conf
+fi
 
 mmd -i tmp/part1.fat32 ::/extlinux
 mcopy -i tmp/part1.fat32 $ROOTDIR/images/sw-versions ::/sw-versions


### PR DESCRIPTION
- add adsd3030 devicetree
- add adsd3030 in start-up scripts
- clean-up usb-gadget.sh

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>