### PR TITLE
drivers: adsd3500: nvidia: adsd3500.c: Initialize framerate default to 10

### DIFF
--- a/drivers/adsd3500/nvidia/L4T_34_1_1/src/adsd3500.c
+++ b/drivers/adsd3500/nvidia/L4T_34_1_1/src/adsd3500.c
@@ -910,6 +910,7 @@ static int adsd3500_probe(struct i2c_client *client,
 	priv->sd = &common_data->subdev;
 	priv->sd->dev = &client->dev;
 	priv->s_data->dev = &client->dev;
+	priv->framerate = 10;
 	mutex_init(&priv->lock);
 
 	ret = camera_common_initialize(common_data, "adsd3500");


### PR DESCRIPTION
Initialize default framerate value to start streaming in cases when SET_FRAMERATE control is not 
explicitly called before STREAM-ON

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>