### PR TITLE
sdk: Allow using offline mode on target as well (not just on PC)

### DIFF
--- a/sdk/src/sensor_enumerator_factory.cpp
+++ b/sdk/src/sensor_enumerator_factory.cpp
@@ -41,11 +41,14 @@
 #ifdef TARGET
 #include "connections/target/target_sensor_enumerator.h"
 #else
-#include "connections/offline/offline_sensor_enumerator.h"
 #include "connections/usb/usb_sensor_enumerator.h"
 #ifdef HAS_NETWORK
 #include "connections/network/network_sensor_enumerator.h"
 #endif
+#endif
+
+#ifdef HAS_OFFLINE
+#include "connections/offline/offline_sensor_enumerator.h"
 #endif
 
 using namespace aditof;


### PR DESCRIPTION
Having an offline sensor (no camera attached to the embedded platform such as NXP) can be useful to test the network server for example.