### PR TITLE
sdcard-images-utils: nxp: Enable CPU Scaling

### DIFF
--- a/sdcard-images-utils/nxp/patches/linux-imx/0001-Enable-I2C-in-PMIC.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0001-Enable-I2C-in-PMIC.patch
@@ -1,7 +1,7 @@
 From 71c27e738ad4c4aad6fbc86a9a9c00f68626cabf Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 15 Apr 2021 11:26:07 +0300
-Subject: [PATCH 01/47] Enable I2C in PMIC
+Subject: [PATCH 01/48] Enable I2C in PMIC
 
 Signed-off-by: TalPilo <tal.pilo@solid-run.com>
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0002-media-spi-Add-initial-support-for-addicmos-camera.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0002-media-spi-Add-initial-support-for-addicmos-camera.patch
@@ -1,7 +1,7 @@
 From 3bda718808e79936c6420f64ca58171111a89c4f Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 11 Mar 2021 11:26:52 +0200
-Subject: [PATCH 02/47] media: spi: Add initial support for addicmos camera
+Subject: [PATCH 02/48] media: spi: Add initial support for addicmos camera
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0003-Changes-for-ADI-camera-required-on-I.MX8M-Plus-captu.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0003-Changes-for-ADI-camera-required-on-I.MX8M-Plus-captu.patch
@@ -1,7 +1,7 @@
 From 23887a00e90977aab90e57c245a6fd144f8c4b80 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 11 Mar 2021 11:35:17 +0200
-Subject: [PATCH 03/47] Changes for ADI camera required on I.MX8M Plus capture
+Subject: [PATCH 03/48] Changes for ADI camera required on I.MX8M Plus capture
  driver
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0004-drivers-staging-media-imx8-Convert-to-single-planar.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0004-drivers-staging-media-imx8-Convert-to-single-planar.patch
@@ -1,7 +1,7 @@
 From d688743cc5f2f72b566d6c1bf8bce9b713cc4df0 Mon Sep 17 00:00:00 2001
 From: btogorean <bogdan.togorean@analog.com>
 Date: Wed, 7 Apr 2021 11:44:38 +0300
-Subject: [PATCH 04/47] drivers: staging: media: imx8: Convert to single planar
+Subject: [PATCH 04/48] drivers: staging: media: imx8: Convert to single planar
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0005-Convert-pixel-format-to-YUYV.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0005-Convert-pixel-format-to-YUYV.patch
@@ -1,7 +1,7 @@
 From ae348f487cb902e98f35417533c19ae4624da575 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 22 Apr 2021 09:36:10 +0300
-Subject: [PATCH 05/47] Convert pixel format to YUYV
+Subject: [PATCH 05/48] Convert pixel format to YUYV
 
 Signed-off-by: btogorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0006-arch-arm64-dts-ADI-TOF-dt.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0006-arch-arm64-dts-ADI-TOF-dt.patch
@@ -1,7 +1,7 @@
 From 30a732a9b88473a43cb9f93e7a798aa60a8341b0 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 16 Apr 2021 09:03:47 +0300
-Subject: [PATCH 06/47] arch: arm64: dts: ADI TOF dt
+Subject: [PATCH 06/48] arch: arm64: dts: ADI TOF dt
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0007-staging-media-imx-imx8-isi-cap-Fix-for-discarding-of.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0007-staging-media-imx-imx8-isi-cap-Fix-for-discarding-of.patch
@@ -1,7 +1,7 @@
 From cac8076e8e72f770be11a456293eb0e5bdc786bf Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 4 May 2021 10:20:23 +0300
-Subject: [PATCH 07/47] staging: media: imx: imx8-isi-cap : Fix for discarding
+Subject: [PATCH 07/48] staging: media: imx: imx8-isi-cap : Fix for discarding
  of the first frame
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0008-drivers-usb-gadget-Add-XU-control-descriptor.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0008-drivers-usb-gadget-Add-XU-control-descriptor.patch
@@ -1,7 +1,7 @@
 From ec69ceda2fec22c2120ecd56335112b1bf89cc42 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 21 May 2021 11:49:25 +0300
-Subject: [PATCH 08/47] drivers: usb: gadget: Add XU control descriptor
+Subject: [PATCH 08/48] drivers: usb: gadget: Add XU control descriptor
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0009-drivers-staging-media-imx-imx8-isi-cap-Add-debug-msg.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0009-drivers-staging-media-imx-imx8-isi-cap-Add-debug-msg.patch
@@ -1,7 +1,7 @@
 From 7fea2e5f8a1996f9a1b89baa6f4b23710d1a975b Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 21 May 2021 12:05:06 +0300
-Subject: [PATCH 09/47] drivers: staging: media: imx: imx8-isi-cap: Add debug
+Subject: [PATCH 09/48] drivers: staging: media: imx: imx8-isi-cap: Add debug
  msg for dropped frames
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0010-drivers-media-spi-addicmos-Add-resolutions-for-max-f.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0010-drivers-media-spi-addicmos-Add-resolutions-for-max-f.patch
@@ -1,7 +1,7 @@
 From ee227e7a7c81393ed1b05a54fcd47851a0c5f1f8 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 21 May 2021 12:07:14 +0300
-Subject: [PATCH 10/47] drivers: media: spi: addicmos: Add resolutions for max
+Subject: [PATCH 10/48] drivers: media: spi: addicmos: Add resolutions for max
  frames FW
 
 When firmware configured for setting frame-end only after all

--- a/sdcard-images-utils/nxp/patches/linux-imx/0011-arch-arm64-dts-imx8mp-aditof-noreg-Allow-PD-up-to-20.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0011-arch-arm64-dts-imx8mp-aditof-noreg-Allow-PD-up-to-20.patch
@@ -1,7 +1,7 @@
 From 993eacd4a10efc80641b613466d063e9baa0e02d Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 21 May 2021 12:10:33 +0300
-Subject: [PATCH 11/47] arch: arm64: dts: imx8mp-aditof-noreg: Allow PD up to
+Subject: [PATCH 11/48] arch: arm64: dts: imx8mp-aditof-noreg: Allow PD up to
  20V and add SPI flash
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0012-usb-typec-tcpm-Remove-tcpm-port-reset.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0012-usb-typec-tcpm-Remove-tcpm-port-reset.patch
@@ -1,7 +1,7 @@
 From d2b63391c770c1601f422ee3d04068ecd4fd8c8d Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 16 Apr 2021 09:01:34 +0300
-Subject: [PATCH 12/47] usb: typec: tcpm: Remove tcpm port reset
+Subject: [PATCH 12/48] usb: typec: tcpm: Remove tcpm port reset
 
 This patch is required to prevent VBUS turning off by the HOST when PD negociation is happening
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0013-drivers-usb-gadget-function-uvc_configfs-Set-guid-to.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0013-drivers-usb-gadget-function-uvc_configfs-Set-guid-to.patch
@@ -1,7 +1,7 @@
 From 2a7644d1fc2330231a4e56e543ed0c2519873f1b Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 22 Jun 2021 17:08:26 +0300
-Subject: [PATCH 13/47] drivers: usb: gadget: function: uvc_configfs: Set guid
+Subject: [PATCH 13/48] drivers: usb: gadget: function: uvc_configfs: Set guid
  to "Y16"
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0014-arch-arm64-imx8mp-adi-tof-noreg-Activate-pull-down-o.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0014-arch-arm64-imx8mp-adi-tof-noreg-Activate-pull-down-o.patch
@@ -1,7 +1,7 @@
 From a962f3519b7076d2215816374765ab39397e982b Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 7 Jul 2021 12:07:54 +0300
-Subject: [PATCH 14/47] arch: arm64: imx8mp-adi-tof-noreg: Activate pull-down
+Subject: [PATCH 14/48] arch: arm64: imx8mp-adi-tof-noreg: Activate pull-down
  on flash WP
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0015-drivers-media-spi-addicmos-Add-custom-control-for-co.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0015-drivers-media-spi-addicmos-Add-custom-control-for-co.patch
@@ -1,7 +1,7 @@
 From 918b9fe5a581b5fb15a0fc3fd6c08734edbf3ebf Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 7 Jul 2021 12:08:46 +0300
-Subject: [PATCH 15/47] drivers: media: spi: addicmos: Add custom control for
+Subject: [PATCH 15/48] drivers: media: spi: addicmos: Add custom control for
  config/claib writing
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0016-adrivers-media-spi-addicmos.c-Add-resolution-for-mod.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0016-adrivers-media-spi-addicmos.c-Add-resolution-for-mod.patch
@@ -1,7 +1,7 @@
 From dbb50f7f0ea76d300c49ddb96c0a61b7ac0363b9 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 23 Jul 2021 09:07:30 +0300
-Subject: [PATCH 16/47] adrivers: media: spi: addicmos.c: Add resolution for
+Subject: [PATCH 16/48] adrivers: media: spi: addicmos.c: Add resolution for
  mode 10
 
 Mode 10 require 4096x256x9 subframes so add corresponding resolution. Also disable default writing of calibration data.

--- a/sdcard-images-utils/nxp/patches/linux-imx/0017-pwm-gpio-Add-a-generic-gpio-based-PWM-driver.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0017-pwm-gpio-Add-a-generic-gpio-based-PWM-driver.patch
@@ -1,7 +1,7 @@
 From 69bb46ef3f40811bff1a360a38bf14fc0b284060 Mon Sep 17 00:00:00 2001
 From: Olliver Schinagl <oliver@schinagl.nl>
 Date: Mon, 26 Oct 2015 22:32:38 +0100
-Subject: [PATCH 17/47] pwm: gpio: Add a generic gpio based PWM driver
+Subject: [PATCH 17/48] pwm: gpio: Add a generic gpio based PWM driver
 
 This patch adds a bit-banging gpio PWM driver. It makes use of hrtimers,
 to allow nano-second resolution, though it obviously strongly depends on

--- a/sdcard-images-utils/nxp/patches/linux-imx/0018-Add-FSYNC-control-using-PWM-framework.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0018-Add-FSYNC-control-using-PWM-framework.patch
@@ -1,7 +1,7 @@
 From de686d67db32b90e9161558ced78f847c092be95 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 17 Sep 2021 11:52:08 +0300
-Subject: [PATCH 18/47] Add FSYNC control using PWM framework
+Subject: [PATCH 18/48] Add FSYNC control using PWM framework
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0019-usb-gadget-Set-lowest-allowed-speed-to-SS.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0019-usb-gadget-Set-lowest-allowed-speed-to-SS.patch
@@ -1,7 +1,7 @@
 From 5fcf2628d00c472fdee8d70afc54c750f1e11fc7 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 7 Oct 2021 16:10:47 +0300
-Subject: [PATCH 19/47] usb: gadget: Set lowest allowed speed to SS
+Subject: [PATCH 19/48] usb: gadget: Set lowest allowed speed to SS
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0020-drivers-media-addicmos-Add-module-parameter-to-enabl.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0020-drivers-media-addicmos-Add-module-parameter-to-enabl.patch
@@ -1,7 +1,7 @@
 From b6e6ba7d41a5246ac0599997a7a2e93c35b32185 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Mon, 8 Nov 2021 11:00:31 +0200
-Subject: [PATCH 20/47] drivers: media: addicmos: Add module parameter to
+Subject: [PATCH 20/48] drivers: media: addicmos: Add module parameter to
  enable FW/Calib loading
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0021-arch-arm64-imx8mp-adi-tof-noreg-Increase-CMA-size.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0021-arch-arm64-imx8mp-adi-tof-noreg-Increase-CMA-size.patch
@@ -1,7 +1,7 @@
 From aa17897e88ba1822a9046281edc198c21a8b80ab Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Mon, 8 Nov 2021 11:01:37 +0200
-Subject: [PATCH 21/47] arch: arm64: imx8mp-adi-tof-noreg: Increase CMA size
+Subject: [PATCH 21/48] arch: arm64: imx8mp-adi-tof-noreg: Increase CMA size
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0022-drivers-media-addicmos.c-Modify-chip_config-ctrl.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0022-drivers-media-addicmos.c-Modify-chip_config-ctrl.patch
@@ -1,7 +1,7 @@
 From b4b46a19e446c6d145beb67559829a48bbc4e1d1 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 10 Nov 2021 15:03:13 +0200
-Subject: [PATCH 22/47] drivers: media: addicmos.c: Modify chip_config ctrl
+Subject: [PATCH 22/48] drivers: media: addicmos.c: Modify chip_config ctrl
 
 Modify chip_config ctrl to get through V4L a block of
 addr<->reg values and loop through in driver and not in SDK.

--- a/sdcard-images-utils/nxp/patches/linux-imx/0023-drivers-mtd-spi-nor-Add-support-for-MX25U1632F.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0023-drivers-mtd-spi-nor-Add-support-for-MX25U1632F.patch
@@ -1,7 +1,7 @@
 From 1be949fcb78ff2c1dfab58c1a1aa63367e96ba10 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 4 Feb 2022 10:17:58 +0200
-Subject: [PATCH 23/47] drivers: mtd: spi-nor: Add support for MX25U1632F
+Subject: [PATCH 23/48] drivers: mtd: spi-nor: Add support for MX25U1632F
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0024-drivers-media-spi-addicmos-Fix-resolution-for-QVGA-m.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0024-drivers-media-spi-addicmos-Fix-resolution-for-QVGA-m.patch
@@ -1,7 +1,7 @@
 From 73dd899a2627665665c15f3f78f113752bc00f62 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 8 Feb 2022 11:51:27 +0200
-Subject: [PATCH 24/47] drivers: media: spi: addicmos: Fix resolution for QVGA
+Subject: [PATCH 24/48] drivers: media: spi: addicmos: Fix resolution for QVGA
  mode
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0025-drivers-media-addicmos-Reduce-line-width-for-QVGA-mo.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0025-drivers-media-addicmos-Reduce-line-width-for-QVGA-mo.patch
@@ -1,7 +1,7 @@
 From a3fbcdec6d155146e7e8b9bd9409866886563bf5 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 8 Feb 2022 14:46:37 +0200
-Subject: [PATCH 25/47] drivers: media: addicmos: Reduce line width for QVGA
+Subject: [PATCH 25/48] drivers: media: addicmos: Reduce line width for QVGA
  mode
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0026-drivers-staging-media-imx-imx8-media-dev.c-Support-b.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0026-drivers-staging-media-imx-imx8-media-dev.c-Support-b.patch
@@ -1,7 +1,7 @@
 From 5c5179bb7c4b3abdad166a12f26159735428ba13 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 5 May 2022 11:49:35 +0300
-Subject: [PATCH 26/47] drivers: staging: media: imx: imx8-media-dev.c: Support
+Subject: [PATCH 26/48] drivers: staging: media: imx: imx8-media-dev.c: Support
  both SPI and I2C
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0027-drivers-staging-media-imx8-isi-cap.c-Add-RAW8-suppor.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0027-drivers-staging-media-imx8-isi-cap.c-Add-RAW8-suppor.patch
@@ -1,7 +1,7 @@
 From 25024fc7296e0e26f155dbcc806303c296947886 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 6 Jan 2022 13:45:38 +0200
-Subject: [PATCH 27/47] drivers: staging: media: imx8-isi-cap.c: Add RAW8
+Subject: [PATCH 27/48] drivers: staging: media: imx8-isi-cap.c: Add RAW8
  support
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0028-drivers-usb-gadget-function-uvc_v4l2.c-Add-support-f.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0028-drivers-usb-gadget-function-uvc_v4l2.c-Add-support-f.patch
@@ -1,7 +1,7 @@
 From e184b1c706b0eb2f2a6a1dd2bc895354b175dbdc Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Mon, 28 Feb 2022 11:07:06 +0200
-Subject: [PATCH 28/47] drivers: usb: gadget: function: uvc_v4l2.c: Add support
+Subject: [PATCH 28/48] drivers: usb: gadget: function: uvc_v4l2.c: Add support
  for SBGGR8/16
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0029-drivers-staging-media-imx-imx8-Fix-SBGGR8-support.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0029-drivers-staging-media-imx-imx8-Fix-SBGGR8-support.patch
@@ -1,7 +1,7 @@
 From bfeef0364c58cd916d0e35e69ffa65330f8fa0a7 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Mon, 28 Feb 2022 11:08:48 +0200
-Subject: [PATCH 29/47] drivers: staging: media: imx: imx8: Fix SBGGR8 support
+Subject: [PATCH 29/48] drivers: staging: media: imx: imx8: Fix SBGGR8 support
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0030-Rename-control-to-ADSD.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0030-Rename-control-to-ADSD.patch
@@ -1,7 +1,7 @@
 From c87c6ea5c5cf0c16bd11d956c4785d4b1715f0a8 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 5 May 2022 11:48:14 +0300
-Subject: [PATCH 30/47] Rename control to ADSD
+Subject: [PATCH 30/48] Rename control to ADSD
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0031-drivers-media-i2c-Initial-revision-of-ADSD3500-drive.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0031-drivers-media-i2c-Initial-revision-of-ADSD3500-drive.patch
@@ -1,7 +1,7 @@
 From 15b15edee0b184aef441cfd36a62f4f904e25c17 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 3 Nov 2021 16:26:00 +0200
-Subject: [PATCH 31/47] drivers: media: i2c: Initial revision of ADSD3500
+Subject: [PATCH 31/48] drivers: media: i2c: Initial revision of ADSD3500
  driver
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0032-drivers-media-spi-addicmos.c-Add-dummy-s_power-to-ke.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0032-drivers-media-spi-addicmos.c-Add-dummy-s_power-to-ke.patch
@@ -1,7 +1,7 @@
 From 7474b0a22aaa9cbbb7c811209103a94cb30a522e Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 10 Mar 2022 10:04:43 +0200
-Subject: [PATCH 32/47] drivers: media: spi: addicmos.c: Add dummy s_power to
+Subject: [PATCH 32/48] drivers: media: spi: addicmos.c: Add dummy s_power to
  keep capture driver happy
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0033-Rename-addicmos-to-adsd3100.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0033-Rename-addicmos-to-adsd3100.patch
@@ -1,7 +1,7 @@
 From 6b2d764391dfd96ebea83482535e599b28a7b5ff Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 5 May 2022 11:36:40 +0300
-Subject: [PATCH 33/47] Rename addicmos to adsd3100
+Subject: [PATCH 33/48] Rename addicmos to adsd3100
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0034-drivers-staging-media-Add-support-for-RAW16.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0034-drivers-staging-media-Add-support-for-RAW16.patch
@@ -1,7 +1,7 @@
 From e7ff8742cbdcabfec4d210dd121229542c0b8d5d Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 19 May 2022 11:54:21 +0300
-Subject: [PATCH 34/47] drivers/staging/media: Add support for RAW16
+Subject: [PATCH 34/48] drivers/staging/media: Add support for RAW16
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0035-drivers-media-i2c-adsd3500-Fix-MP-frames-width-and-h.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0035-drivers-media-i2c-adsd3500-Fix-MP-frames-width-and-h.patch
@@ -1,7 +1,7 @@
 From 275414afd7f22a90cd5ef02a10bc76ac27749730 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Mon, 23 May 2022 15:55:13 +0300
-Subject: [PATCH 35/47] drivers: media: i2c: adsd3500: Fix MP frames width and
+Subject: [PATCH 35/48] drivers: media: i2c: adsd3500: Fix MP frames width and
  height
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0036-media-i2c-adsd3500-Implement-SET-GET-framerate-contr.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0036-media-i2c-adsd3500-Implement-SET-GET-framerate-contr.patch
@@ -1,7 +1,7 @@
 From e31d75deaca4e4de5ae997af9daa58da987e9e35 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 13 Jul 2022 10:54:29 +0300
-Subject: [PATCH 36/47] media: i2c: adsd3500: Implement SET/GET framerate
+Subject: [PATCH 36/48] media: i2c: adsd3500: Implement SET/GET framerate
  control
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0037-drivers-media-adsd-Remove-duplicate-link_freqs.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0037-drivers-media-adsd-Remove-duplicate-link_freqs.patch
@@ -1,7 +1,7 @@
 From dc0d067cd78339c27d839058d064307957eda938 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 2 Aug 2022 17:12:18 +0300
-Subject: [PATCH 37/47] drivers: media: adsd: Remove duplicate link_freqs
+Subject: [PATCH 37/48] drivers: media: adsd: Remove duplicate link_freqs
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0038-drivers-media-adsd3500-Add-AB-test-resolution-suppor.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0038-drivers-media-adsd3500-Add-AB-test-resolution-suppor.patch
@@ -1,7 +1,7 @@
 From 81bfba423f281026d269bf0ab81b159fa2f4cb57 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 17 Aug 2022 09:58:58 +0300
-Subject: [PATCH 38/47] drivers: media: adsd3500: Add AB test resolution
+Subject: [PATCH 38/48] drivers: media: adsd3500: Add AB test resolution
  support
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0039-drivers-media-adsd3100-Revert-adsd3100-to-YUYV.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0039-drivers-media-adsd3100-Revert-adsd3100-to-YUYV.patch
@@ -1,7 +1,7 @@
 From 99ff3626e2fe71520db79399a8a7f46cc825c3c4 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 17 Aug 2022 10:04:07 +0300
-Subject: [PATCH 39/47] drivers: media: adsd3100: Revert adsd3100 to YUYV
+Subject: [PATCH 39/48] drivers: media: adsd3100: Revert adsd3100 to YUYV
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0040-arch-arm64-imx8mp-adi-tof-adsd3500.dts-Disable-1P8-a.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0040-arch-arm64-imx8mp-adi-tof-adsd3500.dts-Disable-1P8-a.patch
@@ -1,7 +1,7 @@
 From 896799a0aa09f476bbd83c041dd426d5ca770a21 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 17 Aug 2022 10:14:34 +0300
-Subject: [PATCH 40/47] arch: arm64: imx8mp-adi-tof-adsd3500.dts: Disable 1P8
+Subject: [PATCH 40/48] arch: arm64: imx8mp-adi-tof-adsd3500.dts: Disable 1P8
  and 0P8 reg
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0041-drivers-media-i2c-adsd3500-Add-ADSD30303-resolutions.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0041-drivers-media-i2c-adsd3500-Add-ADSD30303-resolutions.patch
@@ -1,7 +1,7 @@
 From c8d8865fa8b9d2b54f6e760f2e068d7119fe46ae Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Tue, 23 Aug 2022 16:39:27 +0300
-Subject: [PATCH 41/47] drivers: media: i2c: adsd3500: Add ADSD30303
+Subject: [PATCH 41/48] drivers: media: i2c: adsd3500: Add ADSD30303
  resolutions
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0042-drivers-media-common-v4l2-loopback-Add-v4l2-loopback.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0042-drivers-media-common-v4l2-loopback-Add-v4l2-loopback.patch
@@ -1,7 +1,7 @@
 From b733d15ef79f74df4703c8a1c858fbe380d479d3 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 29 Sep 2022 13:27:06 +0300
-Subject: [PATCH 42/47] drivers: media: common: v4l2-loopback: Add
+Subject: [PATCH 42/48] drivers: media: common: v4l2-loopback: Add
  v4l2-loopback driver
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0043-drivers-media-spi-adsd3100-Add-1-pase-mode.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0043-drivers-media-spi-adsd3100-Add-1-pase-mode.patch
@@ -1,7 +1,7 @@
 From e1e02886a4db741039bb1a5e36ec70faa43b8804 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 29 Sep 2022 13:32:58 +0300
-Subject: [PATCH 43/47] drivers: media: spi: adsd3100: Add 1 pase mode
+Subject: [PATCH 43/48] drivers: media: spi: adsd3100: Add 1 pase mode
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0044-drivers-staging-media-imx-Fix-YUYV-mode.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0044-drivers-staging-media-imx-Fix-YUYV-mode.patch
@@ -1,7 +1,7 @@
 From eeaaf0db1a28fe945caaffb0d15d9a269713328a Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Thu, 29 Sep 2022 13:35:04 +0300
-Subject: [PATCH 44/47] drivers: staging: media: imx: Fix YUYV mode
+Subject: [PATCH 44/48] drivers: staging: media: imx: Fix YUYV mode
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0045-drivers-media-i2c-adsd3500-Add-adsd3030-support.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0045-drivers-media-i2c-adsd3500-Add-adsd3030-support.patch
@@ -1,7 +1,7 @@
 From 32e7a7c9563b0593ece46ca4400150b13ea2a009 Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Wed, 9 Nov 2022 14:39:43 +0200
-Subject: [PATCH 45/47] drivers: media: i2c: adsd3500: Add adsd3030 support
+Subject: [PATCH 45/48] drivers: media: i2c: adsd3500: Add adsd3030 support
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
 ---

--- a/sdcard-images-utils/nxp/patches/linux-imx/0046-drivers-media-i2c-adsd3500.c-Allow-zero-BPP-for-dept.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0046-drivers-media-i2c-adsd3500.c-Allow-zero-BPP-for-dept.patch
@@ -1,7 +1,7 @@
 From b3f182add9088f4a6e206f657c44bc062951a3be Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 25 Nov 2022 16:30:12 +0200
-Subject: [PATCH 46/47] drivers: media: i2c: adsd3500.c: Allow zero BPP for
+Subject: [PATCH 46/48] drivers: media: i2c: adsd3500.c: Allow zero BPP for
  depth
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0047-drivers-media-adsd3500-Add-support-fo-3F3P-3F2P-VGA-.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0047-drivers-media-adsd3500-Add-support-fo-3F3P-3F2P-VGA-.patch
@@ -1,7 +1,7 @@
 From 5452e2b99136868473c202b0ee59cc1f46e859ea Mon Sep 17 00:00:00 2001
 From: Bogdan Togorean <bogdan.togorean@analog.com>
 Date: Fri, 25 Nov 2022 16:32:48 +0200
-Subject: [PATCH 47/47] drivers: media: adsd3500: Add support fo 3F3P 3F2P VGA
+Subject: [PATCH 47/48] drivers: media: adsd3500: Add support fo 3F3P 3F2P VGA
  & QVGA RAW
 
 Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>

--- a/sdcard-images-utils/nxp/patches/linux-imx/0048-arch-arm64-boot-dts-freescale-imx8mp-adi-tof-Enable-.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0048-arch-arm64-boot-dts-freescale-imx8mp-adi-tof-Enable-.patch
@@ -1,0 +1,130 @@
+From a3983c1bf5436ef9be1ba4869b715b87c31aae67 Mon Sep 17 00:00:00 2001
+From: Bogdan Togorean <bogdan.togorean@analog.com>
+Date: Tue, 13 Dec 2022 16:46:30 +0200
+Subject: [PATCH 48/48] arch/arm64/boot/dts/freescale/imx8mp-adi-tof: Enable
+ CPU scaling governor
+
+Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>
+---
+ .../dts/freescale/imx8mp-adi-tof-adsd3030.dts | 20 +++++++++++++++++--
+ .../dts/freescale/imx8mp-adi-tof-adsd3500.dts | 20 +++++++++++++++++--
+ .../dts/freescale/imx8mp-adi-tof-noreg.dts    | 20 +++++++++++++++++--
+ 3 files changed, 54 insertions(+), 6 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3030.dts b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3030.dts
+index 603ccf4a3b04..2ce6babbd21f 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3030.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3030.dts
+@@ -236,6 +236,22 @@ linux,cma {
+ 		};
+ };
+ 
++&A53_0 {
++	cpu-supply = <&buck2>;
++};
++
++&A53_1 {
++	cpu-supply = <&buck2>;
++};
++
++&A53_2 {
++	cpu-supply = <&buck2>;
++};
++
++&A53_3 {
++	cpu-supply = <&buck2>;
++};
++
+ &clk {
+ 	init-on-array = <IMX8MP_CLK_HSIO_ROOT>;
+ };
+@@ -303,8 +319,8 @@ buck1: BUCK1 {
+ 
+ 			buck2: BUCK2 {
+ 				regulator-name = "BUCK2";
+-				regulator-min-microvolt = <600000>;
+-				regulator-max-microvolt = <2187500>;
++				regulator-min-microvolt = <720000>;
++				regulator-max-microvolt = <1025000>;
+ 				regulator-boot-on;
+ 				regulator-always-on;
+ 				regulator-ramp-delay = <3125>;
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3500.dts b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3500.dts
+index 9cd1d65b02b3..0e4a8261c5b8 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3500.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3500.dts
+@@ -230,6 +230,22 @@ pwm: pwm-gpio {
+ 	};
+ };
+ 
++&A53_0 {
++	cpu-supply = <&buck2>;
++};
++
++&A53_1 {
++	cpu-supply = <&buck2>;
++};
++
++&A53_2 {
++	cpu-supply = <&buck2>;
++};
++
++&A53_3 {
++	cpu-supply = <&buck2>;
++};
++
+ &clk {
+ 	init-on-array = <IMX8MP_CLK_HSIO_ROOT>;
+ };
+@@ -297,8 +313,8 @@ buck1: BUCK1 {
+ 
+ 			buck2: BUCK2 {
+ 				regulator-name = "BUCK2";
+-				regulator-min-microvolt = <600000>;
+-				regulator-max-microvolt = <2187500>;
++				regulator-min-microvolt = <720000>;
++				regulator-max-microvolt = <1025000>;
+ 				regulator-boot-on;
+ 				regulator-always-on;
+ 				regulator-ramp-delay = <3125>;
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
+index e8a81ab5e80d..2b1079c95487 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-noreg.dts
+@@ -242,6 +242,22 @@ linux,cma {
+ 		};
+ };
+ 
++&A53_0 {
++	cpu-supply = <&buck2>;
++};
++
++&A53_1 {
++	cpu-supply = <&buck2>;
++};
++
++&A53_2 {
++	cpu-supply = <&buck2>;
++};
++
++&A53_3 {
++	cpu-supply = <&buck2>;
++};
++
+ &clk {
+ 	init-on-array = <IMX8MP_CLK_HSIO_ROOT>;
+ };
+@@ -309,8 +325,8 @@ buck1: BUCK1 {
+ 
+ 			buck2: BUCK2 {
+ 				regulator-name = "BUCK2";
+-				regulator-min-microvolt = <600000>;
+-				regulator-max-microvolt = <2187500>;
++				regulator-min-microvolt = <720000>;
++				regulator-max-microvolt = <1025000>;
+ 				regulator-boot-on;
+ 				regulator-always-on;
+ 				regulator-ramp-delay = <3125>;
+-- 
+2.38.1
+


### PR DESCRIPTION
Enable CPU Scaling and support dynamic throttling in range 1.2GHz - 1.8Ghz

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>