### PR TITLE
drivers: adsd3500: nvidia: L4T_34_1_1: src: adsd3500.c: Fix QVGA resolution

### DIFF
--- a/drivers/adsd3500/nvidia/L4T_34_1_1/src/adsd3500.c
+++ b/drivers/adsd3500/nvidia/L4T_34_1_1/src/adsd3500.c
@@ -892,7 +892,7 @@ static int adsd3500_probe(struct i2c_client *client,
 	common_data->ops = &adsd3500_common_ops;
 	common_data->ctrl_handler = &priv->ctrl_handler;
 	common_data->dev = &client->dev;
-	common_data->frmfmt = &adsd3500_frmfmt[2];
+	common_data->frmfmt = &adsd3500_frmfmt[0];
 	common_data->colorfmt = camera_common_find_datafmt(
 					  ADSD3500_DEFAULT_DATAFMT);
 	common_data->numctrls = 0;


### PR DESCRIPTION
Because frmfmt table was skipping first 2 elements the 256x320 and 1280x320 resolutions were rejected

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>