### PR TITLE
server and network_sensor: skip frame serialization

### DIFF
--- a/sdk/src/connections/network/network.cpp
+++ b/sdk/src/connections/network/network.cpp
@@ -64,6 +64,9 @@ int nBytes = 0;          /*no of bytes sent*/
 int recv_data_error = 0; /*flag for recv data*/
 char server_msg[] = "Connection Allowed";
 
+//frame requst without serialization
+uint8_t *m_frame = NULL;
+
 /*Declare static members*/
 std::vector<lws *> Network::web_socket;
 std::vector<lws_context *> Network::context;
@@ -425,18 +428,43 @@ int Network::callback_function(struct lws *wsi,
                 in = static_cast<void *>(clientData->data.data());
                 len = clientData->data.size();
             }
+            std::cout << "The first BYTE: " << static_cast<char *>(in)[0]
+                      << std::endl;
+            if (static_cast<unsigned char *>(in)[0] == '0') {
+                // process message without frame
+                google::protobuf::io::ArrayInputStream ais(
+                    static_cast<char *>(in) + 1, static_cast<int>(len) - 1);
+                CodedInputStream coded_input(&ais);
+                recv_buff[connectionId].ParseFromCodedStream(&coded_input);
 
-            // process message
-            google::protobuf::io::ArrayInputStream ais(in,
-                                                       static_cast<int>(len));
-            CodedInputStream coded_input(&ais);
-            recv_buff[connectionId].ParseFromCodedStream(&coded_input);
+                recv_data_error = 0;
+                Data_Received[connectionId] = true;
 
-            recv_data_error = 0;
-            Data_Received[connectionId] = true;
+                /*Notify the host SDK that data is received from server*/
+                Cond_Var[connectionId].notify_all();
+            } else {
+                // process message of only frame data
 
-            /*Notify the host SDK that data is received from server*/
-            Cond_Var[connectionId].notify_all();
+                std::cout << "Protobuf frame message\n";
+                uint8_t* m_frame=NULL;
+                int m_frameLength;
+                m_frameLength = static_cast<int>(len) - 1;
+
+                if (m_frame != NULL)
+                {
+                    free(m_frame);
+                    m_frame = (uint8_t*)malloc(m_frameLength * sizeof(uint8_t));
+                }
+
+                recv_buff[connectionId].add_bytes_payload(static_cast<char *>(in) + 1, m_frameLength-1);
+                // memcpy(m_frame, static_cast<char *>(in) + 1, m_frameLength);
+
+                recv_data_error = 0;
+                Data_Received[connectionId] = true;
+
+                /*Notify the host SDK that data is received from server*/
+                Cond_Var[connectionId].notify_all();
+            }
 
         } else {
             // append message

--- a/sdk/src/connections/network/network.h
+++ b/sdk/src/connections/network/network.h
@@ -73,6 +73,8 @@ class Network {
 
     static payload::ClientRequest send_buff[MAX_CAMERA_NUM];
     static payload::ServerResponse recv_buff[MAX_CAMERA_NUM];
+    uint8_t *m_frame;
+    int m_frameLength;
 
     //! ServerConnect() - APi to initialize the websocket and connect to
     //! websocket server

--- a/sdk/src/connections/network/network_depth_sensor.cpp
+++ b/sdk/src/connections/network/network_depth_sensor.cpp
@@ -403,8 +403,7 @@ aditof::Status NetworkDepthSensor::getFrame(uint16_t *buffer) {
     }
 
     //when using ITOF camera the data is already deinterleaved, so a simple copy is enough
-    memcpy(buffer, net->recv_buff[m_sensorIndex].bytes_payload(0).c_str(),
-           net->recv_buff[m_sensorIndex].bytes_payload(0).length());
+    memcpy(buffer, net->recv_buff[m_sensorIndex].bytes_payload(0).c_str(), net->recv_buff[m_sensorIndex].bytes_payload(0).length());
 
     return status;
 }


### PR DESCRIPTION
Frame serialization in case of quarter MP requires 2 miliseconds and in case of MP requires 8 miliseconds in plus

app/server: added 1 byte in front of every libwebsocket packet to determine if the message is serialized or not

network_sensor: after libwebsocket obtains the message the first byte is checked and based in it's value the following part is deserialized or not

current_status: working protocol, needs enhancement