### PR TITLE
server and network_sensor: frame transmission without serialization

### DIFF
--- a/examples/first-frame-network/main.cpp
+++ b/examples/first-frame-network/main.cpp
@@ -36,7 +36,6 @@
 #include <glog/logging.h>
 #include <iostream>
 
-
 using namespace aditof;
 
 int main(int argc, char *argv[]) {
@@ -93,7 +92,7 @@ int main(int argc, char *argv[]) {
         std::cout << "no frame type available!";
         return 0;
     }
-    status = camera->setFrameType("lr-qnative");
+    status = camera->setFrameType("lrqmp");
     if (status != Status::OK) {
         LOG(ERROR) << "Could not set camera frame type!";
         return 0;
@@ -105,29 +104,14 @@ int main(int argc, char *argv[]) {
         return 0;
     }
     aditof::Frame frame;
-    
-    clock_t current_ticks, delta_ticks;
-    clock_t fps = 0;
 
-    while (true)
-    {
-        current_ticks = clock();
-        status = camera->requestFrame(&frame);
-
-        delta_ticks = clock() - current_ticks; //the time, in ms, that took to render the scene
-        if(delta_ticks > 0)
-            fps = CLOCKS_PER_SEC / delta_ticks;
-        std::cout << fps << std::endl;
-
-        
-        // if (status != Status::OK) {
-        //     LOG(ERROR) << "Could not request frame!";
-        //     return 0;
-        // } 
+    status = camera->requestFrame(&frame);
+    if (status != Status::OK) {
+        LOG(ERROR) << "Could not request frame!";
+        return 0;
+    } else {
+        LOG(INFO) << "succesfully requested frame!";
     }
-    
-
-
 
     uint16_t *data1;
     status = frame.getData("ir", &data1);

--- a/examples/first-frame-network/main.cpp
+++ b/examples/first-frame-network/main.cpp
@@ -36,6 +36,7 @@
 #include <glog/logging.h>
 #include <iostream>
 
+
 using namespace aditof;
 
 int main(int argc, char *argv[]) {
@@ -92,7 +93,7 @@ int main(int argc, char *argv[]) {
         std::cout << "no frame type available!";
         return 0;
     }
-    status = camera->setFrameType("lrqmp");
+    status = camera->setFrameType("lr-qnative");
     if (status != Status::OK) {
         LOG(ERROR) << "Could not set camera frame type!";
         return 0;
@@ -104,14 +105,29 @@ int main(int argc, char *argv[]) {
         return 0;
     }
     aditof::Frame frame;
+    
+    clock_t current_ticks, delta_ticks;
+    clock_t fps = 0;
 
-    status = camera->requestFrame(&frame);
-    if (status != Status::OK) {
-        LOG(ERROR) << "Could not request frame!";
-        return 0;
-    } else {
-        LOG(INFO) << "succesfully requested frame!";
+    while (true)
+    {
+        current_ticks = clock();
+        status = camera->requestFrame(&frame);
+
+        delta_ticks = clock() - current_ticks; //the time, in ms, that took to render the scene
+        if(delta_ticks > 0)
+            fps = CLOCKS_PER_SEC / delta_ticks;
+        std::cout << fps << std::endl;
+
+        
+        // if (status != Status::OK) {
+        //     LOG(ERROR) << "Could not request frame!";
+        //     return 0;
+        // } 
     }
+    
+
+
 
     uint16_t *data1;
     status = frame.getData("ir", &data1);

--- a/sdk/src/connections/network/network.cpp
+++ b/sdk/src/connections/network/network.cpp
@@ -64,9 +64,6 @@ int nBytes = 0;          /*no of bytes sent*/
 int recv_data_error = 0; /*flag for recv data*/
 char server_msg[] = "Connection Allowed";
 
-//frame requst without serialization
-uint8_t *m_frame = NULL;
-
 /*Declare static members*/
 std::vector<lws *> Network::web_socket;
 std::vector<lws_context *> Network::context;

--- a/sdk/src/connections/network/network.cpp
+++ b/sdk/src/connections/network/network.cpp
@@ -442,20 +442,11 @@ int Network::callback_function(struct lws *wsi,
                 Cond_Var[connectionId].notify_all();
             } else {
                 // process message of only frame data
-                uint8_t *m_frame = NULL;
                 int m_frameLength;
                 m_frameLength = static_cast<int>(len) - 1;
 
-                if (m_frame != NULL) {
-                    free(m_frame);
-                    m_frame =
-                        (uint8_t *)malloc(m_frameLength * sizeof(uint8_t));
-                }
-
                 recv_buff[connectionId].add_bytes_payload(
                     static_cast<char *>(in) + 1, m_frameLength - 1);
-                // memcpy(m_frame, static_cast<char *>(in) + 1, m_frameLength);
-
                 recv_data_error = 0;
                 Data_Received[connectionId] = true;
 

--- a/sdk/src/connections/network/network.h
+++ b/sdk/src/connections/network/network.h
@@ -73,7 +73,6 @@ class Network {
 
     static payload::ClientRequest send_buff[MAX_CAMERA_NUM];
     static payload::ServerResponse recv_buff[MAX_CAMERA_NUM];
-    uint8_t *m_frame;
     int m_frameLength;
 
     //! ServerConnect() - APi to initialize the websocket and connect to

--- a/sdk/src/connections/network/network.h
+++ b/sdk/src/connections/network/network.h
@@ -73,6 +73,8 @@ class Network {
 
     static payload::ClientRequest send_buff[MAX_CAMERA_NUM];
     static payload::ServerResponse recv_buff[MAX_CAMERA_NUM];
+    uint8_t *m_frame;
+    int m_frameLength;
 
     //! ServerConnect() - APi to initialize the websocket and connect to
     //! websocket server


### PR DESCRIPTION
Frame serialization in case of quarter MP requires 2 miliseconds and in case of MP requires 8 miliseconds in plus

app/server: added 1 byte in front of every libwebsocket packet to determine if the message is serialized or not

network_sensor: after libwebsocket obtains the message the first byte is checked and based in it's value the following part is deserialized or not

Frame transmission without serialization finalized. (Needs testing on MP datasizes)