### PR TITLE
sdk: Don't match length when comparing v4l2 names

### DIFF
--- a/sdk/src/cameras/itof-camera/nvidia/target_definitions.h
+++ b/sdk/src/cameras/itof-camera/nvidia/target_definitions.h
@@ -32,7 +32,7 @@
 #ifndef TARGET_DEFINITIONS_H
 #define TARGET_DEFINITIONS_H
 
-static const char *CAPTURE_DEVICE_NAME = "vi-output, adsd3500 2-0038";
+static const char *CAPTURE_DEVICE_NAME = "vi-output, adsd3500";
 
 static const char *EEPROM_DEV_PATH = "/dev/mtdblock0";
 static const char *EEPROM_NAME = "MX25U6435F";

--- a/sdk/src/connections/target/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500_sensor.cpp
@@ -255,7 +255,7 @@ aditof::Status Adsd3500Sensor::open() {
             return Status::GENERIC_ERROR;
         }
 
-        if (strcmp((char *)cap.card, cardName)) {
+        if (strncmp((char *)cap.card, cardName, strlen(cardName))) {
             LOG(WARNING) << "CAPTURE Device " << cap.card;
             LOG(WARNING) << "Read " << cardName;
             return Status::GENERIC_ERROR;


### PR DESCRIPTION
On Nvidia, v4l2 device name might vary depending on the I2C address or bus number.

Signed-off-by: Dan <dan.nechita@analog.com>