### PR TITLE
sdk: Remove unnecessary memcpy of AB frame for Crosby native modes

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -772,20 +772,6 @@ aditof::Status CameraItof::requestFrame(aditof::Frame *frame,
             uint16_t *mpAbFrame;
             frame->getData("ir", &mpAbFrame);
 
-            if (m_details.frameType.type == "lr-native") {
-                memcpy(mpAbFrame,
-                       frameDataLocation + m_details.frameType.height *
-                                               m_details.frameType.width * 3,
-                       m_details.frameType.height * m_details.frameType.width *
-                           sizeof(uint16_t));
-            } else {
-                memcpy(mpAbFrame,
-                       frameDataLocation + m_details.frameType.height *
-                                               m_details.frameType.width * 2,
-                       m_details.frameType.height * m_details.frameType.width *
-                           sizeof(uint16_t));
-            }
-
             //TO DO: shift with 4 because we use only 12 bits
             for (unsigned int i = 0;
                  i < (m_details.frameType.height * m_details.frameType.width);


### PR DESCRIPTION
Signed-off-by: Dan Nechita <dan.nechita@analog.com>