### PR TITLE
drivers: adsd3500: nvidia: Configure for 1.25Gbps lane rate

### DIFF
--- a/drivers/adsd3500/nvidia/L4T_32_7_1/src/tegra194-camera-adsd3500-a00.dtsi
+++ b/drivers/adsd3500/nvidia/L4T_32_7_1/src/tegra194-camera-adsd3500-a00.dtsi
@@ -206,7 +206,7 @@
 			line_length = "512";
 			inherent_gain = "1";
 			mclk_multiplier = "4";
-			pix_clk_hz = "125000000";
+			pix_clk_hz = "208333333";
 
 			min_gain_val = "0"; /* dB */
 			max_gain_val = "48"; /* dB */
@@ -238,7 +238,7 @@
 			line_length = "1024";
 			inherent_gain = "1";
 			mclk_multiplier = "4";
-			pix_clk_hz = "125000000";
+			pix_clk_hz = "312500000";
 
 			min_gain_val = "0";
 			max_gain_val = "48";
@@ -270,7 +270,7 @@
 			line_length = "1280";
 			inherent_gain = "1";
 			mclk_multiplier = "4";
-			pix_clk_hz = "125000000";
+			pix_clk_hz = "312500000";
 
 			min_gain_val = "0";
 			max_gain_val = "48";
@@ -302,7 +302,7 @@
 			line_length = "1536";
 			inherent_gain = "1";
 			mclk_multiplier = "4";
-			pix_clk_hz = "125000000";
+			pix_clk_hz = "312500000";
 
 			min_gain_val = "0";
 			max_gain_val = "48";
@@ -334,7 +334,7 @@
 			line_length = "1792";
 			inherent_gain = "1";
 			mclk_multiplier = "4";
-			pix_clk_hz = "125000000";
+			pix_clk_hz = "312500000";
 
 			min_gain_val = "0";
 			max_gain_val = "48";
@@ -366,7 +366,7 @@
 			line_length = "2048";
 			inherent_gain = "1";
 			mclk_multiplier = "4";
-			pix_clk_hz = "125000000";
+			pix_clk_hz = "312500000";
 
 			min_gain_val = "0";
 			max_gain_val = "48";
@@ -398,7 +398,7 @@
 			line_length = "2304";
 			inherent_gain = "1";
 			mclk_multiplier = "4";
-			pix_clk_hz = "125000000";
+			pix_clk_hz = "312500000";
 
 			min_gain_val = "0";
 			max_gain_val = "48";
@@ -430,7 +430,7 @@
 			line_length = "2560";
 			inherent_gain = "1";
 			mclk_multiplier = "4";
-			pix_clk_hz = "125000000";
+			pix_clk_hz = "312500000";
 
 			min_gain_val = "0";
 			max_gain_val = "48";
@@ -462,7 +462,7 @@
 			line_length = "3072";
 			inherent_gain = "1";
 			mclk_multiplier = "4";
-			pix_clk_hz = "125000000";
+			pix_clk_hz = "208333333";
 
 			min_gain_val = "0";
 			max_gain_val = "48";

--- a/drivers/adsd3500/nvidia/L4T_34_1_1/src/tegra194-p2888-0001-p2822-0000.dts
+++ b/drivers/adsd3500/nvidia/L4T_34_1_1/src/tegra194-p2888-0001-p2822-0000.dts
@@ -222,7 +222,7 @@
 				line_length = "256";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "208333333";
 
 				min_gain_val = "0"; /* dB */
 				max_gain_val = "48"; /* dB */
@@ -254,7 +254,7 @@
 				line_length = "1280";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "312500000";
 
 				min_gain_val = "0";
 				max_gain_val = "48";
@@ -286,7 +286,7 @@
 				line_length = "512";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "208333333";
 
 				min_gain_val = "0";
 				max_gain_val = "48";
@@ -318,7 +318,7 @@
 				line_length = "2560";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "312500000";
 
 				min_gain_val = "0";
 				max_gain_val = "48";
@@ -350,7 +350,7 @@
 				line_length = "512";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "208333333";
 
 				min_gain_val = "0";
 				max_gain_val = "48";
@@ -382,7 +382,7 @@
 				line_length = "2048";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "312500000";
 
 				min_gain_val = "0";
 				max_gain_val = "48";
@@ -414,7 +414,7 @@
 				line_length = "2560";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "312500000";
 
 				min_gain_val = "0";
 				max_gain_val = "48";

--- a/drivers/adsd3500/nvidia/L4T_34_1_1/src/tegra194-p3668-all-p3509-0000.dts
+++ b/drivers/adsd3500/nvidia/L4T_34_1_1/src/tegra194-p3668-all-p3509-0000.dts
@@ -194,7 +194,7 @@
 				line_length = "256";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "208333333";
 
 				min_gain_val = "0"; /* dB */
 				max_gain_val = "48"; /* dB */
@@ -226,7 +226,7 @@
 				line_length = "1280";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "312500000";
 
 				min_gain_val = "0";
 				max_gain_val = "48";
@@ -258,7 +258,7 @@
 				line_length = "512";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "208333333";
 
 				min_gain_val = "0";
 				max_gain_val = "48";
@@ -290,7 +290,7 @@
 				line_length = "2560";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "312500000";
 
 				min_gain_val = "0";
 				max_gain_val = "48";
@@ -322,7 +322,7 @@
 				line_length = "512";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "208333333";
 
 				min_gain_val = "0";
 				max_gain_val = "48";
@@ -354,7 +354,7 @@
 				line_length = "2048";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "312500000";
 
 				min_gain_val = "0";
 				max_gain_val = "48";
@@ -386,7 +386,7 @@
 				line_length = "2560";
 				inherent_gain = "1";
 				mclk_multiplier = "4";
-				pix_clk_hz = "417000000";
+				pix_clk_hz = "312500000";
 
 				min_gain_val = "0";
 				max_gain_val = "48";


### PR DESCRIPTION
This patch will also fix the reset ADSD3500 problem but only for 1.25Gbps lanerate. For 2.5Gbps deskew is required form TX side

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>