### PR TITLE
examples/tof-viewer: Quick (dirty) fix to make playback work with 'raw'

### DIFF
--- a/examples/tof-viewer/src/ADIToFRecorder.cpp
+++ b/examples/tof-viewer/src/ADIToFRecorder.cpp
@@ -866,6 +866,15 @@ void ADIToFRecorder::playbackThread() {
         }
 
         auto frame = std::make_shared<aditof::Frame>();
+        aditof::FrameDataDetails dataDetails;
+        dataDetails.type = "depth";
+        dataDetails.width = m_frameDetails.width;
+        dataDetails.height = m_frameDetails.height;
+        m_frameDetails.dataDetails.emplace_back(dataDetails);
+        dataDetails.type = "ir";
+        dataDetails.width = m_frameDetails.width;
+        dataDetails.height = m_frameDetails.height;
+        m_frameDetails.dataDetails.emplace_back(dataDetails);
         frame->setDetails(m_frameDetails);
 
         frame->getData("ir", &frameDataLocationIR);


### PR DESCRIPTION
The frame has an internal structure (that refers to what content exists: depth, AB, etc. and the resolution for each of them). The current implementation of the recording process doesn't save anything about the frame structure. So when playback starts, we don't know how to construct the frame.
The quick fix is to assume depth and AB has been recorded. A full refactor is needed.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>