### PR TITLE
Allow setting the time to wait for adsd3500_read_cmd

### DIFF
--- a/apps/server/server.cpp
+++ b/apps/server/server.cpp
@@ -555,8 +555,11 @@ void invoke_sdk_api(payload::ClientRequest buff_recv) {
     case ADSD3500_READ_CMD: {
         uint16_t cmd = static_cast<uint16_t>(buff_recv.func_int32_param(0));
         uint16_t data;
+        unsigned int usDelay =
+            static_cast<unsigned int>(buff_recv.func_int32_param(1));
 
-        aditof::Status status = camDepthSensor->adsd3500_read_cmd(cmd, &data);
+        aditof::Status status =
+            camDepthSensor->adsd3500_read_cmd(cmd, &data, usDelay);
         if (status == aditof::Status::OK) {
             buff_send.add_int32_payload(static_cast<::google::int32>(data));
         }

--- a/apps/uvc-app/tof-sdk-interface.cpp
+++ b/apps/uvc-app/tof-sdk-interface.cpp
@@ -255,8 +255,11 @@ void handleClientRequest(const char *in_buf, const size_t in_len,
         std::string controlName = request.func_strings_param(0);
         uint16_t cmd = static_cast<uint32_t>(request.func_int32_param(0));
         uint16_t *data = new uint16_t;
+        unsigned int usDelay =
+            static_cast<unsigned int>(request.func_int32_param(1));
 
-        aditof::Status status = camDepthSensor->adsd3500_read_cmd(cmd, data);
+        aditof::Status status =
+            camDepthSensor->adsd3500_read_cmd(cmd, data, usDelay);
 
         if (status == aditof::Status::OK) {
             response.add_bytes_payload(data, sizeof(uint16_t));

--- a/sdk/include/aditof/depth_sensor_interface.h
+++ b/sdk/include/aditof/depth_sensor_interface.h
@@ -138,9 +138,12 @@ class DepthSensorInterface {
      * @brief Send a read command to adsd3500.
      * @param cmd - the command to be sent
      * @param[out] data - the variable where the read data will be stored
+     * @param usDelay - the number of microseconds to wait between the host command
+     * and the actual read
      * @return Status
      */
-    virtual aditof::Status adsd3500_read_cmd(uint16_t cmd, uint16_t *data) = 0;
+    virtual aditof::Status adsd3500_read_cmd(uint16_t cmd, uint16_t *data,
+                                             unsigned int usDelay = 0) = 0;
 
     /**
      * @brief Send a write command to adsd3500.

--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -1838,7 +1838,12 @@ aditof::Status CameraItof::adsd3500GetSensorTemperature(uint16_t &tmpValue) {
     using namespace aditof;
     Status status = Status::OK;
 
-    status = m_depthSensor->adsd3500_read_cmd(0x0054, &tmpValue);
+    unsigned int usDelay = 0;
+    if (m_cameraFps > 0) {
+        usDelay =
+            static_cast<unsigned int>((1 / (double)m_cameraFps) * 1000000);
+    }
+    status = m_depthSensor->adsd3500_read_cmd(0x0054, &tmpValue, usDelay);
     if (status != Status::OK) {
         LOG(ERROR) << "Can not read sensor temperature";
         return Status::GENERIC_ERROR;
@@ -1850,7 +1855,12 @@ aditof::Status CameraItof::adsd3500GetLaserTemperature(uint16_t &tmpValue) {
     using namespace aditof;
     Status status = Status::OK;
 
-    status = m_depthSensor->adsd3500_read_cmd(0x0055, &tmpValue);
+    unsigned int usDelay = 0;
+    if (m_cameraFps > 0) {
+        usDelay =
+            static_cast<unsigned int>((1 / (double)m_cameraFps) * 1000000);
+    }
+    status = m_depthSensor->adsd3500_read_cmd(0x0055, &tmpValue, usDelay);
     if (status != Status::OK) {
         LOG(ERROR) << "Can not read laser temperature";
         return Status::GENERIC_ERROR;

--- a/sdk/src/connections/network/network_depth_sensor.cpp
+++ b/sdk/src/connections/network/network_depth_sensor.cpp
@@ -655,7 +655,8 @@ aditof::Status NetworkDepthSensor::getName(std::string &name) const {
 }
 
 aditof::Status NetworkDepthSensor::adsd3500_read_cmd(uint16_t cmd,
-                                                     uint16_t *data) {
+                                                     uint16_t *data,
+                                                     unsigned int usDelay) {
     using namespace aditof;
 
     Network *net = m_implData->handle.net;
@@ -669,6 +670,8 @@ aditof::Status NetworkDepthSensor::adsd3500_read_cmd(uint16_t cmd,
     net->send_buff[m_sensorIndex].set_func_name("Adsd3500ReadCmd");
     net->send_buff[m_sensorIndex].add_func_int32_param(
         static_cast<::google::int32>(cmd));
+    net->send_buff[m_sensorIndex].add_func_int32_param(
+        static_cast<::google::int32>(usDelay));
     net->send_buff[m_sensorIndex].set_expect_reply(true);
 
     if (net->SendCommand() != 0) {

--- a/sdk/src/connections/network/network_depth_sensor.h
+++ b/sdk/src/connections/network/network_depth_sensor.h
@@ -69,8 +69,8 @@ class NetworkDepthSensor : public aditof::DepthSensorInterface {
     virtual aditof::Status getHandle(void **handle) override;
     virtual aditof::Status getName(std::string &name) const override;
 
-    virtual aditof::Status adsd3500_read_cmd(uint16_t cmd,
-                                             uint16_t *data) override;
+    virtual aditof::Status adsd3500_read_cmd(uint16_t cmd, uint16_t *data,
+                                             unsigned int usDelay = 0) override;
     virtual aditof::Status adsd3500_write_cmd(uint16_t cmd,
                                               uint16_t data) override;
     virtual aditof::Status

--- a/sdk/src/connections/offline/offline_depth_sensor.cpp
+++ b/sdk/src/connections/offline/offline_depth_sensor.cpp
@@ -85,7 +85,8 @@ aditof::Status OfflineDepthSensor::getName(std::string &name) const {
 }
 
 aditof::Status OfflineDepthSensor::adsd3500_read_cmd(uint16_t cmd,
-                                                     uint16_t *data) {
+                                                     uint16_t *data,
+                                                     unsigned int usDelay) {
     return aditof::Status::OK;
 }
 

--- a/sdk/src/connections/offline/offline_depth_sensor.h
+++ b/sdk/src/connections/offline/offline_depth_sensor.h
@@ -39,8 +39,8 @@ class OfflineDepthSensor : public aditof::DepthSensorInterface {
     virtual aditof::Status getHandle(void **handle) override;
     virtual aditof::Status getName(std::string &name) const override;
 
-    virtual aditof::Status adsd3500_read_cmd(uint16_t cmd,
-                                             uint16_t *data) override;
+    virtual aditof::Status adsd3500_read_cmd(uint16_t cmd, uint16_t *data,
+                                             unsigned int usDelay) override;
     virtual aditof::Status adsd3500_write_cmd(uint16_t cmd,
                                               uint16_t data) override;
     virtual aditof::Status

--- a/sdk/src/connections/target/adsd3100_sensor.cpp
+++ b/sdk/src/connections/target/adsd3100_sensor.cpp
@@ -886,7 +886,8 @@ aditof::Status Adsd3100Sensor::getName(std::string &name) const {
     return aditof::Status::OK;
 }
 
-aditof::Status Adsd3100Sensor::adsd3500_read_cmd(uint16_t cmd, uint16_t *data) {
+aditof::Status Adsd3100Sensor::adsd3500_read_cmd(uint16_t cmd, uint16_t *data,
+                                                 unsigned int usDelay) {
     LOG(INFO) << "Adsd3500 is not connected to this sensor type!";
     return aditof::Status::UNAVAILABLE;
 }

--- a/sdk/src/connections/target/adsd3100_sensor.h
+++ b/sdk/src/connections/target/adsd3100_sensor.h
@@ -73,8 +73,8 @@ class Adsd3100Sensor : public aditof::DepthSensorInterface,
     virtual aditof::Status getHandle(void **handle) override;
     virtual aditof::Status getName(std::string &name) const override;
 
-    virtual aditof::Status adsd3500_read_cmd(uint16_t cmd,
-                                             uint16_t *data) override;
+    virtual aditof::Status adsd3500_read_cmd(uint16_t cmd, uint16_t *data,
+                                             unsigned int usDelay = 0) override;
     virtual aditof::Status adsd3500_write_cmd(uint16_t cmd,
                                               uint16_t data) override;
     virtual aditof::Status

--- a/sdk/src/connections/target/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500_sensor.cpp
@@ -870,7 +870,8 @@ aditof::Status Adsd3500Sensor::getName(std::string &name) const {
     return aditof::Status::OK;
 }
 
-aditof::Status Adsd3500Sensor::adsd3500_read_cmd(uint16_t cmd, uint16_t *data) {
+aditof::Status Adsd3500Sensor::adsd3500_read_cmd(uint16_t cmd, uint16_t *data,
+                                                 unsigned int usDelay) {
     using namespace aditof;
     struct VideoDev *dev = &m_implData->videoDevs[0];
     Status status = Status::OK;
@@ -904,8 +905,7 @@ aditof::Status Adsd3500Sensor::adsd3500_read_cmd(uint16_t cmd, uint16_t *data) {
 
     extCtrl.p_u8 = buf;
 
-    //wait for the last frame processing time, needed for adsd3500
-    usleep(double(1.0) / m_sensorFps * 1000000);
+    usleep(usDelay);
 
     if (xioctl(dev->sfd, VIDIOC_S_EXT_CTRLS, &extCtrls) == -1) {
         LOG(WARNING) << "Reading Adsd3500 error "

--- a/sdk/src/connections/target/adsd3500_sensor.h
+++ b/sdk/src/connections/target/adsd3500_sensor.h
@@ -72,8 +72,8 @@ class Adsd3500Sensor : public aditof::DepthSensorInterface,
     virtual aditof::Status getHandle(void **handle) override;
     virtual aditof::Status getName(std::string &name) const override;
 
-    virtual aditof::Status adsd3500_read_cmd(uint16_t cmd,
-                                             uint16_t *data) override;
+    virtual aditof::Status adsd3500_read_cmd(uint16_t cmd, uint16_t *data,
+                                             unsigned int usDelay = 0) override;
     virtual aditof::Status adsd3500_write_cmd(uint16_t cmd,
                                               uint16_t data) override;
     virtual aditof::Status

--- a/sdk/src/connections/usb/linux/usb_depth_sensor_linux.cpp
+++ b/sdk/src/connections/usb/linux/usb_depth_sensor_linux.cpp
@@ -790,7 +790,8 @@ aditof::Status UsbDepthSensor::getName(std::string &name) const {
     return aditof::Status::OK;
 }
 
-aditof::Status UsbDepthSensor::adsd3500_read_cmd(uint16_t cmd, uint16_t *data) {
+aditof::Status UsbDepthSensor::adsd3500_read_cmd(uint16_t cmd, uint16_t *data,
+                                                 unsigned int usDelay) {
     using namespace aditof;
     Status status = Status::OK;
 
@@ -798,6 +799,7 @@ aditof::Status UsbDepthSensor::adsd3500_read_cmd(uint16_t cmd, uint16_t *data) {
     usb_payload::ClientRequest requestMsg;
     requestMsg.set_func_name(usb_payload::FunctionName::ADSD3500_READ_CMD);
     requestMsg.add_func_int32_param(static_cast<::google::int32>(cmd));
+    requestMsg.add_func_int32_param(static_cast<::google::int32>(usDelay));
 
     // Send request
     std::string requestStr;

--- a/sdk/src/connections/usb/usb_depth_sensor.h
+++ b/sdk/src/connections/usb/usb_depth_sensor.h
@@ -75,8 +75,8 @@ class UsbDepthSensor : public aditof::DepthSensorInterface {
     virtual aditof::Status getHandle(void **handle) override;
     virtual aditof::Status getName(std::string &name) const override;
 
-    virtual aditof::Status adsd3500_read_cmd(uint16_t cmd,
-                                             uint16_t *data) override;
+    virtual aditof::Status adsd3500_read_cmd(uint16_t cmd, uint16_t *data,
+                                             unsigned int usDelay = 0) override;
     virtual aditof::Status adsd3500_write_cmd(uint16_t cmd,
                                               uint16_t data) override;
     virtual aditof::Status

--- a/sdk/src/connections/usb/windows/usb_depth_sensor_windows.cpp
+++ b/sdk/src/connections/usb/windows/usb_depth_sensor_windows.cpp
@@ -979,7 +979,8 @@ aditof::Status UsbDepthSensor::getName(std::string &name) const {
     return aditof::Status::OK;
 }
 
-aditof::Status UsbDepthSensor::adsd3500_read_cmd(uint16_t cmd, uint16_t *data) {
+aditof::Status UsbDepthSensor::adsd3500_read_cmd(uint16_t cmd, uint16_t *data,
+                                                 unsigned int usDelay) {
     using namespace aditof;
 
     Status status = Status::OK;


### PR DESCRIPTION
This delay is now used for reading temperature but should not force other calls to adsd3500_read_cmd() that not need this delay. Also, validate the FPS value when calculating the time to wait in order to avoid division by 0.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>