### PR TITLE
sdk: Add missing header for close()

### DIFF
--- a/sdk/src/connections/target/gpio.cpp
+++ b/sdk/src/connections/target/gpio.cpp
@@ -40,6 +40,7 @@
 #include <fcntl.h>
 #include <linux/gpio.h>
 #include <sys/ioctl.h>
+#include <unistd.h>
 
 using namespace aditof;
 Gpio::Gpio(const std::string &charDeviceName, int gpioNumber)


### PR DESCRIPTION
This usually works when compiling with a native compiler but gives a compiler error when cross compiling. So use the exact header where close() is declared.