### PR TITLE
cmake: Copy the glog DLL when building on Windows

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -31,10 +31,11 @@ function(PopulateforPython targetdir)
         )
     endif()
     if (WIN32)
-        if (EXISTS "${glog_DIR}/../../../bin")
-            add_custom_command( TARGET aditofpython POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_directory "${glog_DIR}/../../../bin" "${CMAKE_CURRENT_BINARY_DIR}/${targetdir}/$<CONFIG>"
-            )
+        if (EXISTS "${GLOG_BIN_DIR}")
+            if (WITH_GLOG_DEPENDENCY)
+                add_custom_command( TARGET aditofpython POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_directory ${GLOG_BIN_DIR} "${CMAKE_CURRENT_BINARY_DIR}/${targetdir}/$<CONFIG>")
+            endif()
         endif()
 
         if (EXISTS "${LWS_CMAKE_DIR}/../bin")

--- a/examples/data_collect/CMakeLists.txt
+++ b/examples/data_collect/CMakeLists.txt
@@ -49,6 +49,11 @@ if (WITH_NETWORK)
 		COMMAND ${CMAKE_COMMAND} -E copy_directory ${LWS_CMAKE_DIR}/../bin ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
 		)
 endif()
+    if (WITH_GLOG_DEPENDENCY)
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${GLOG_BIN_DIR} ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
+        )
+    endif()
 else()
 add_custom_command( TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_BINARY_DIR}/sdk/" $<TARGET_FILE_DIR:${PROJECT_NAME}>/.

--- a/examples/first-frame-network/CMakeLists.txt
+++ b/examples/first-frame-network/CMakeLists.txt
@@ -22,4 +22,9 @@ if( WIN32 )
 		COMMAND ${CMAKE_COMMAND} -E copy_directory ${LWS_CMAKE_DIR}/../bin ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
 		)
 	endif()
+    if (WITH_GLOG_DEPENDENCY)
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${GLOG_BIN_DIR} ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
+        )
+    endif()
 endif()

--- a/examples/first-frame/CMakeLists.txt
+++ b/examples/first-frame/CMakeLists.txt
@@ -22,4 +22,9 @@ if( WIN32 )
 		COMMAND ${CMAKE_COMMAND} -E copy_directory ${LWS_CMAKE_DIR}/../bin ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
 		)
 	endif()
+    if (WITH_GLOG_DEPENDENCY)
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${GLOG_BIN_DIR} ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
+        )
+    endif()
 endif()

--- a/examples/tof-viewer/CMakeLists.txt
+++ b/examples/tof-viewer/CMakeLists.txt
@@ -112,4 +112,9 @@ if(WIN32)
 		COMMAND ${CMAKE_COMMAND} -E copy_directory ${LWS_CMAKE_DIR}/../bin ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
 		)
 	endif()
+	if (WITH_GLOG_DEPENDENCY)
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${GLOG_BIN_DIR} ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
+        )
+    endif()
 endif()

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -16,6 +16,8 @@ add_definitions(-DSDK_EXPORTS)
 
 if(WITH_GLOG_DEPENDENCY)
     find_package(glog 0.3.5 REQUIRED)
+    set(GLOG_BIN_DIR "${glog_DIR}/../../../bin")
+    set(GLOG_BIN_DIR ${GLOG_BIN_DIR} PARENT_SCOPE)
 endif()
 
 if(WITH_PROTOBUF_DEPENDENCY)


### PR DESCRIPTION
glog DLL is required to be next to each executable. These changes will copy the DLL during the build process.