### PR TITLE
sdcard-images-utils: nxp: patches: Add ADSD3500 interrupt handling

### DIFF
--- a/sdcard-images-utils/nxp/patches/linux-imx/0051-drivers-media-i2c-adsd3500-add-Debugfs-read-support.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0051-drivers-media-i2c-adsd3500-add-Debugfs-read-support.patch
@@ -1,0 +1,300 @@
+From 476ff24d884ea5e73d88089dc29271a46cbaf9e3 Mon Sep 17 00:00:00 2001
+From: Akshaya <akshayakumar.haribhatt@analog.com>
+Date: Wed, 15 Mar 2023 16:21:44 +0530
+Subject: [PATCH] drivers media i2c adsd3500 Add Debugfs read support
+
+---
+ .../dts/freescale/imx8mp-adi-tof-adsd3030.dts |   5 +-
+ .../dts/freescale/imx8mp-adi-tof-adsd3500.dts |   3 +-
+ drivers/media/i2c/adsd3500.c                  | 148 ++++++++++++++++++
+ drivers/media/i2c/adsd3500_regs.h             |   3 +
+ 4 files changed, 156 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3030.dts b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3030.dts
+index 2ce6babbd21f..8681cff58ea2 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3030.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3030.dts
+@@ -403,6 +403,7 @@ adsd3500@38 {
+ 		compatible = "adi,adsd3500";
+ 		reg = <0x38>;
+ 		reset-gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
++		interrupt-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+ 		port {
+ 			adsd3500_ep: endpoint {
+ 				remote-endpoint = <&mipi_csi0_ep>;
+@@ -905,7 +906,7 @@ MX8MP_IOMUXC_SAI3_RXC__GPIO4_IO29		0xd6
+ 
+ 	pinctrl_i2c2_synaptics_dsx_io: synaptics_dsx_iogrp {
+ 		fsl,pins = <
+-			MX8MP_IOMUXC_GPIO1_IO09__GPIO1_IO09		0x16
++			MX8MP_IOMUXC_GPIO1_IO09__SDMA2_EXT_EVENT00	0x1c4
+ 		>;
+ 	};
+ 
+@@ -1196,4 +1197,4 @@ cap_device {
+ 
+ &dsp {
+ 	status = "okay";
+-};
+\ No newline at end of file
++};
+diff --git a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3500.dts b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3500.dts
+index 0e4a8261c5b8..eb898b6ac10b 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3500.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-adi-tof-adsd3500.dts
+@@ -397,6 +397,7 @@ adsd3500@38 {
+ 		compatible = "adi,adsd3500";
+ 		reg = <0x38>;
+ 		reset-gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
++		interrupt-gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+ 		port {
+ 			adsd3500_ep: endpoint {
+ 				remote-endpoint = <&mipi_csi0_ep>;
+@@ -941,7 +942,7 @@ MX8MP_IOMUXC_SAI3_RXC__GPIO4_IO29		0xd6
+ 
+ 	pinctrl_i2c2_synaptics_dsx_io: synaptics_dsx_iogrp {
+ 		fsl,pins = <
+-			MX8MP_IOMUXC_GPIO1_IO09__GPIO1_IO09		0x16
++			MX8MP_IOMUXC_GPIO1_IO09__SDMA2_EXT_EVENT00	0x1c4
+ 		>;
+ 	};
+ 
+diff --git a/drivers/media/i2c/adsd3500.c b/drivers/media/i2c/adsd3500.c
+index aa10a8e17c74..bbeef72419ed 100644
+--- a/drivers/media/i2c/adsd3500.c
++++ b/drivers/media/i2c/adsd3500.c
+@@ -15,6 +15,8 @@
+ #include <linux/of.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/regmap.h>
++#include <linux/debugfs.h>
++#include <linux/sched/signal.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-fwnode.h>
+ #include <media/v4l2-subdev.h>
+@@ -62,6 +64,11 @@ struct adsd3500 {
+ 	bool streaming;
+ 
+ 	struct gpio_desc *rst_gpio;
++	struct gpio_desc *irq_gpio;
++	int    irq;
++	struct dentry *debugfs;
++	struct task_struct *task;
++	int signalnum;
+ };
+ 
+ static inline struct adsd3500 *to_adsd3500(struct v4l2_subdev *sd)
+@@ -90,6 +97,111 @@ static const s64 link_freq_tbl[] = {
+ 	732000000
+ };
+ 
++static int debug_open(struct inode *inode, struct file *file)
++{
++	struct adsd3500 *adsd3500;
++
++	if (inode->i_private)
++		file->private_data = inode->i_private;
++
++	adsd3500 = (struct adsd3500 *) file->private_data;
++
++	dev_dbg(adsd3500->dev, "Entered debugfs file open\n");
++
++	return 0;
++}
++
++static int debug_release(struct inode *inode, struct file *file)
++{
++	struct adsd3500 *adsd3500;
++	struct task_struct *release_task = get_current();
++
++	if (inode->i_private)
++		file->private_data = inode->i_private;
++
++	adsd3500 = (struct adsd3500 *) file->private_data;
++
++	dev_dbg(adsd3500->dev, "Entered debugfs file close\n");
++	if(release_task == adsd3500->task) {
++		adsd3500->task = NULL;
++	}
++
++	return 0;
++}
++
++ssize_t debug_read(struct file *file, char __user *buff, size_t count, loff_t *offset){
++
++	struct adsd3500 *adsd3500 = file->private_data;
++	unsigned int read_val;
++	unsigned int len;
++	int ret;
++	char data[16];
++
++	dev_dbg(adsd3500->dev, "Entered debugfs file read\n");
++	ret = regmap_read(adsd3500->regmap, GET_IMAGER_STATUS_CMD, &read_val);
++	if (ret < 0) {
++		dev_err(adsd3500->dev, "Read of get status cmd failed.\n");
++		len = snprintf(data, sizeof(data), "Read failed\n");
++	}
++	else{
++		dev_dbg(adsd3500->dev, "Read the error status: %.4X\n", read_val);
++		len = snprintf(data, sizeof(data), "0x%.4X\n",read_val);
++	}
++	return simple_read_from_buffer(buff, count, offset, data, len);
++
++}
++
++ssize_t debug_write(struct file *file, const char __user *buff, size_t count, loff_t *offset){
++
++	struct adsd3500 *adsd3500 = file->private_data;
++
++	dev_dbg(adsd3500->dev, "Entered debugfs file write\n");
++
++	return count;
++}
++
++static long debug_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
++{
++	struct adsd3500 *adsd3500;
++
++	adsd3500 = (struct adsd3500 *) file->private_data;
++
++	dev_dbg(adsd3500->dev, "Entered debugfs ioctl\n");
++	if (cmd == USER_TASK) {
++		dev_dbg(adsd3500->dev, "Registered user task\n");
++		adsd3500->task = get_current();
++		adsd3500->signalnum = SIGETX;
++	}
++
++	return 0;
++}
++
++static const struct file_operations adsd3500_debug_fops = {
++	.owner 	= THIS_MODULE,
++	.open   = debug_open,
++	.read 	= debug_read,
++	.write  = debug_write,
++	.unlocked_ioctl = debug_ioctl,
++	.release= debug_release,
++};
++
++static irqreturn_t adsd3500_irq_handler(int irq,void *priv)
++{
++
++	struct adsd3500 *adsd3500 = (struct adsd3500 *) priv;
++
++	dev_dbg(adsd3500-> dev, "Entered ADSD3500 IRQ handler\n");
++
++	if (adsd3500->task != NULL) {
++		dev_dbg(adsd3500->dev, "Sending signal to app\n");
++		if(send_sig_info(SIGETX, SEND_SIG_PRIV, adsd3500->task) < 0) {
++			dev_err(adsd3500->dev, "Unable to send signal\n");
++		}
++	}
++
++	return IRQ_HANDLED;
++
++}
+ /* Elements of the structure must be ordered ascending by width & height */
+ static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
+ 	{ //RAW8 8BPP
+@@ -286,6 +398,7 @@ static bool adsd3500_regmap_accessible_reg(struct device *dev, unsigned int reg)
+ 		case GET_IMAGER_JBLF_STATE:
+ 		case GET_IMAGER_JBLF_FILT_SIZE:
+ 		case GET_FRAMERATE_CMD:
++		case GET_IMAGER_STATUS_CMD:
+ 			return 1;
+ 		default:
+ 			return 0;
+@@ -961,6 +1074,17 @@ static int adsd3500_init_ctrls(struct adsd3500 *priv){
+ 	return 0;
+ }
+ 
++static int adsd3500_debugfs_init(struct adsd3500 *priv){
++
++	priv->debugfs = debugfs_create_dir("adsd3500", NULL);
++	if(!priv->debugfs)
++		return -ENOMEM;
++
++	debugfs_create_file("value", 0660, priv->debugfs, priv, &adsd3500_debug_fops);
++
++	return 0;
++}
++
+ static int adsd3500_parse_dt(struct adsd3500 *priv){
+ 	struct v4l2_fwnode_endpoint bus_cfg = {.bus_type = V4L2_MBUS_CSI2_DPHY};
+ 	struct fwnode_handle *endpoint;
+@@ -988,6 +1112,17 @@ static int adsd3500_parse_dt(struct adsd3500 *priv){
+ 		return PTR_ERR(priv->rst_gpio);
+ 	}
+ 
++	priv->irq_gpio = gpiod_get_optional(dev, "interrupt", GPIOD_IN);
++	if (IS_ERR(priv->irq_gpio)) {
++		dev_err(dev, "Unable to get \"interrupt\" gpio\n");
++		return PTR_ERR(priv->irq_gpio);
++	}
++
++	priv->irq = gpiod_to_irq(priv->irq_gpio);
++	if(priv->irq < 0){
++		dev_err(dev, "Unable to find the valid irq\n");
++	}
++
+ 	priv->current_config.use_vc = of_property_read_bool(dev->of_node, "adi,use-vc");
+ 
+ 	return 0;
+@@ -1020,6 +1155,15 @@ static int adsd3500_probe(struct i2c_client *client)
+ 	if(adsd3500->rst_gpio)
+ 		gpiod_set_value(adsd3500->rst_gpio, 1);
+ 
++	ret = devm_request_irq(dev, adsd3500->irq, adsd3500_irq_handler,
++			       IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING,
++			       client->name, adsd3500);
++	if(ret < 0){
++		dev_err(dev, "Failed to request IRQ %d\n",adsd3500->irq);
++	}
++
++	ret= adsd3500_debugfs_init(adsd3500);
++
+ 	ret = adsd3500_init_ctrls(adsd3500);
+ 	if (ret < 0)
+ 		goto release_gpio;
+@@ -1062,6 +1206,7 @@ static int adsd3500_probe(struct i2c_client *client)
+ 	mutex_destroy(&adsd3500->lock);
+ release_gpio:
+ 	gpiod_put(adsd3500->rst_gpio);
++	gpiod_put(adsd3500->irq_gpio);
+ 
+ 	return ret;
+ }
+@@ -1073,7 +1218,10 @@ static int adsd3500_remove(struct i2c_client *client)
+ 
+ 	v4l2_async_unregister_subdev(&adsd3500->sd);
+ 	media_entity_cleanup(&adsd3500->sd.entity);
++	devm_free_irq(adsd3500->dev, adsd3500->irq, adsd3500);
+ 	gpiod_put(adsd3500->rst_gpio);
++	gpiod_put(adsd3500->irq_gpio);
++	debugfs_remove(adsd3500->debugfs);
+ 	v4l2_ctrl_handler_free(&adsd3500->ctrls);
+ 	mutex_destroy(&adsd3500->lock);
+ 
+diff --git a/drivers/media/i2c/adsd3500_regs.h b/drivers/media/i2c/adsd3500_regs.h
+index 95f88fe6deff..db09c27b1688 100644
+--- a/drivers/media/i2c/adsd3500_regs.h
++++ b/drivers/media/i2c/adsd3500_regs.h
+@@ -44,6 +44,7 @@
+ #define GET_IMAGER_CONFIDENCE_TRSHLD		0x0016
+ #define GET_IMAGER_JBLF_STATE				0x0017
+ #define GET_IMAGER_JBLF_FILT_SIZE			0x0018
++#define GET_IMAGER_STATUS_CMD				0x0020
+ 
+ #define SET_FRAMERATE_CMD                   0x0022
+ #define GET_FRAMERATE_CMD                   0x0023
+@@ -55,5 +56,7 @@
+ #define SWITCH_TO_BURST_VAL         	    0x0000
+ 
+ #define ADSD3500_CHIP_ID					0x5931
++#define USER_TASK 				_IOW('A',1,int32_t*)
++#define SIGETX 					44
+ 
+ #endif
+-- 
+2.28.0
+

--- a/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/usr/share/systemd/tof-power-en.sh
+++ b/sdcard-images-utils/nxp/patches/ubuntu_overlay/step1/usr/share/systemd/tof-power-en.sh
@@ -122,7 +122,7 @@ if [[ $BOARD == "NXP i.MX8MPlus ADI TOF carrier + ADSD3030" ]]; then
 #U12	#OC6
 	echo 502 > /sys/class/gpio/export
 	echo out > /sys/class/gpio/gpio502/direction
-	echo 0 > /sys/class/gpio/gpio502/value
+	echo 1 > /sys/class/gpio/gpio502/value
 
 #U12	#FLASH_WP
 	echo 503 > /sys/class/gpio/export
@@ -154,6 +154,10 @@ if [[ $BOARD == "NXP i.MX8MPlus ADI TOF carrier + ADSD3030" ]]; then
 #U5	#EN_0V8
 	echo 509 > /sys/class/gpio/export
 	echo 1 > /sys/class/gpio/gpio509/value
+
+#U5 #SHDWN_SEL
+	echo 510 > /sys/class/gpio/export
+	echo 0 > /sys/class/gpio/gpio510/value
 
 	# Pull reset high
 	echo 1 > /sys/class/gpio/gpio122/value


### PR DESCRIPTION
This commit implement ADSA3500 fault register read mechanism. There are 2 interfaces exposed:

- sysfs readback
- registering to a system event triggered by ADSD3500 interrupt