### PR TITLE
File format index was not modified during format refactoring

### DIFF
--- a/examples/tof-viewer/src/ADIMainWindow.cpp
+++ b/examples/tof-viewer/src/ADIMainWindow.cpp
@@ -899,9 +899,6 @@ void ADIMainWindow::ShowRecordTree() {
                 //Add a file extension
                 switch (filterIndex) {
                 case 1:
-                    // not supported anymore
-                    break;
-                case 2: //Raw file
                     saveFile += ".raw";
                     if (!isPlaying) {
                         //"Press" the play button, in case it is not pressed.


### PR DESCRIPTION
During last frame format the filter index was not adequately adapted to the .raw file format 