### PR TITLE
getFrame error should be reported to callee

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -744,6 +744,7 @@ aditof::Status CameraItof::requestFrame(aditof::Frame *frame,
     status = m_depthSensor->getFrame(frameDataLocation);
     if (status != Status::OK) {
         LOG(WARNING) << "Failed to get frame from device";
+        return status;
     }
 
     if (!m_adsd3500Enabled && !m_isOffline &&


### PR DESCRIPTION
Issue:
The API `requestFrame` is reporting success status `Status::OK` even if internal API call `status = m_depthSensor->getFrame(frameDataLocation)` is failed.

Fix:
Return proper error code to application layer instead of `tatus::OK`.