### PR TITLE
Viewer memory bug

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -1059,7 +1059,8 @@ aditof::Status CameraItof::initComputeLibrary(void) {
     aditof::Status status = aditof::Status::OK;
 
     LOG(INFO) << "initComputeLibrary";
-    //freeComputeLibrary();
+
+    freeComputeLibrary();
     uint8_t convertedMode;
 
     status = ModeInfo::getInstance()->convertCameraMode(m_details.mode,
@@ -1129,14 +1130,10 @@ aditof::Status CameraItof::initComputeLibrary(void) {
 
 aditof::Status CameraItof::freeComputeLibrary(void) {
 
-    freeConfigData();
-
-    if (NULL != m_tofi_compute_context) {
-        LOG(INFO) << "freeComputeLibrary";
+    if (m_tofi_compute_context != NULL) {
         FreeTofiCompute(m_tofi_compute_context);
         m_tofi_compute_context = NULL;
     }
-
     if (m_tofi_config != NULL) {
         FreeTofiConfig(m_tofi_config);
         m_tofi_config = NULL;
@@ -1145,6 +1142,7 @@ aditof::Status CameraItof::freeComputeLibrary(void) {
 }
 
 aditof::Status CameraItof::loadConfigData(void) {
+
     freeConfigData();
 
     if (m_ini_depth_map.size() > 0) {

--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -1086,12 +1086,13 @@ aditof::Status CameraItof::initComputeLibrary(void) {
             }
 
             ConfigFileData depth_ini = {pData, dataSize};
-            if (m_adsd3500Enabled || m_isOffline) {
+
+            if ((m_adsd3500Enabled || m_isOffline) && !m_tofi_config) {
                 m_tofi_config = InitTofiConfig_isp((ConfigFileData *)&depth_ini,
                                                    convertedMode, &status,
                                                    m_xyz_dealias_data);
             } else {
-                if (calData.p_data != NULL) {
+                if (calData.p_data != NULL && !m_tofi_config) {
                     m_tofi_config = InitTofiConfig(&calData, NULL, &depth_ini,
                                                    convertedMode, &status);
                 } else {
@@ -1099,8 +1100,10 @@ aditof::Status CameraItof::initComputeLibrary(void) {
                 }
             }
         } else {
-            m_tofi_config =
-                InitTofiConfig(&calData, NULL, NULL, convertedMode, &status);
+            if (!m_tofi_config) {
+                m_tofi_config = InitTofiConfig(&calData, NULL, NULL,
+                                               convertedMode, &status);
+            }
         }
 
         if ((m_tofi_config == NULL) ||
@@ -1110,8 +1113,9 @@ aditof::Status CameraItof::initComputeLibrary(void) {
             return aditof::Status::GENERIC_ERROR;
 
         } else {
-            m_tofi_compute_context =
-                InitTofiCompute(m_tofi_config->p_tofi_cal_config, &status);
+            if (!m_tofi_compute_context)
+                m_tofi_compute_context =
+                    InitTofiCompute(m_tofi_config->p_tofi_cal_config, &status);
             if (m_tofi_compute_context == NULL || status != ADI_TOFI_SUCCESS) {
                 LOG(ERROR) << "InitTofiCompute failed";
                 return aditof::Status::GENERIC_ERROR;

--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -1960,6 +1960,9 @@ aditof::Status CameraItof::parseJsonFileContent() {
         m_enableEdgeConfidence =
             getValueFromJSON(config_json, "enableEdgeConfidence");
 
+        // Delete memory allocated for JSON
+        cJSON_Delete(config_json);
+
     } else if (!config.empty()) {
         LOG(ERROR) << "Couldn't parse config file: " << config.c_str();
         return Status::GENERIC_ERROR;

--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -1173,7 +1173,19 @@ aditof::Status CameraItof::loadConfigData(void) {
 }
 
 void CameraItof::freeConfigData(void) {
-    // TO DO:
+
+    if (m_depthINIDataMap.size() > 0) {
+        for (auto it = m_depthINIDataMap.begin(); it != m_depthINIDataMap.end();
+             ++it) {
+            free((void *)(it->second.p_data));
+        }
+        m_depthINIDataMap.clear();
+    }
+    if (m_calData.p_data) {
+        free((void *)(m_calData.p_data));
+        m_calData.p_data = nullptr;
+        m_calData.size = 0;
+    }
 }
 
 aditof::Status CameraItof::isValidFrame(const int numTotalFrames) {

--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -141,6 +141,7 @@ CameraItof::CameraItof(
 CameraItof::~CameraItof() {
     cleanupTempFiles();
     freeConfigData();
+    freeComputeLibrary();
     // m_device->toggleFsync();
     if (m_eepromInitialized) {
         m_eeprom->close();

--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -397,7 +397,11 @@ class CameraItof : public aditof::Camera {
     bool m_adsd3500_master;
     bool m_isOffline;
 
-    FileData m_calData;
+    FileData m_calData = {
+        .p_data = NULL,
+        .size = 0
+    };
+    
     FileData m_depthINIData;
     std::map<std::string, FileData> m_depthINIDataMap;
     uint8_t *m_jconfigData = NULL;

--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -397,11 +397,8 @@ class CameraItof : public aditof::Camera {
     bool m_adsd3500_master;
     bool m_isOffline;
 
-    FileData m_calData = {
-        .p_data = NULL,
-        .size = 0
-    };
-    
+    FileData m_calData = {NULL, 0};
+
     FileData m_depthINIData;
     std::map<std::string, FileData> m_depthINIDataMap;
     uint8_t *m_jconfigData = NULL;


### PR DESCRIPTION
So far two additional free was added:
* freeing up the memory allocated for depthIniDataMap
* freeing up the json

So far there are other memory allocations in libtofi_compute that are not freed. The following stack trace shows the use of mallocs/callocs that are used without free, (while hitting the play button of ADIViwer two times):

```
=689017== HEAP SUMMARY:
==689017==     in use at exit: 13,371,176 bytes in 3,485 blocks
==689017==   total heap usage: 101,980 allocs, 98,495 frees, 183,719,747 bytes allocated
==689017== 
==689017== 586 (120 direct, 466 indirect) bytes in 1 blocks are definitely lost in loss record 2,229 of 2,271
==689017==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==689017==    by 0x56FBBEC: InitTofiConfig_isp (in /home/robi/Workspace_tof/libs/libtofi_config.so)
==689017==    by 0x4C3DB75: CameraItof::initComputeLibrary() (camera_itof.cpp:1058)
==689017==    by 0x4C3B454: CameraItof::setFrameType(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (camera_itof.cpp:696)
==689017==    by 0x151A27: adiMainWindow::ADIMainWindow::prepareCamera(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (ADIMainWindow.cpp:1162)
==689017==    by 0x15200C: adiMainWindow::ADIMainWindow::PlayCCD(int, int) (ADIMainWindow.cpp:1209)
==689017==    by 0x14D7D4: adiMainWindow::ADIMainWindow::render() (ADIMainWindow.cpp:405)
==689017==    by 0x12EA70: main (ADIToF.cpp:88)
==689017== 
==689017== 1,048,576 bytes in 1 blocks are possibly lost in loss record 2,262 of 2,271
==689017==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==689017==    by 0x56FB55A: ConfigureCCBData (in /home/robi/Workspace_tof/libs/libtofi_config.so)
==689017==    by 0x56FBD16: InitTofiConfig_isp (in /home/robi/Workspace_tof/libs/libtofi_config.so)
==689017==    by 0x4C3DB75: CameraItof::initComputeLibrary() (camera_itof.cpp:1058)
==689017==    by 0x4C3B454: CameraItof::setFrameType(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (camera_itof.cpp:696)
==689017==    by 0x151A27: adiMainWindow::ADIMainWindow::prepareCamera(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (ADIMainWindow.cpp:1162)
==689017==    by 0x15200C: adiMainWindow::ADIMainWindow::PlayCCD(int, int) (ADIMainWindow.cpp:1209)
==689017==    by 0x14D7D4: adiMainWindow::ADIMainWindow::render() (ADIMainWindow.cpp:405)
==689017==    by 0x12EA70: main (ADIToF.cpp:88)
==689017== 
==689017== 1,048,576 bytes in 1 blocks are possibly lost in loss record 2,263 of 2,271
==689017==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==689017==    by 0x56FAE86: GenerateXYZTables (in /home/robi/Workspace_tof/libs/libtofi_config.so)
==689017==    by 0x56FB5D2: ConfigureCCBData (in /home/robi/Workspace_tof/libs/libtofi_config.so)
==689017==    by 0x56FBD16: InitTofiConfig_isp (in /home/robi/Workspace_tof/libs/libtofi_config.so)
==689017==    by 0x4C3DB75: CameraItof::initComputeLibrary() (camera_itof.cpp:1058)
==689017==    by 0x4C3B454: CameraItof::setFrameType(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (camera_itof.cpp:696)
==689017==    by 0x151A27: adiMainWindow::ADIMainWindow::prepareCamera(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (ADIMainWindow.cpp:1162)
==689017==    by 0x15200C: adiMainWindow::ADIMainWindow::PlayCCD(int, int) (ADIMainWindow.cpp:1209)
==689017==    by 0x14D7D4: adiMainWindow::ADIMainWindow::render() (ADIMainWindow.cpp:405)
==689017==    by 0x12EA70: main (ADIToF.cpp:88)
==689017== 
==689017== 1,048,576 bytes in 1 blocks are possibly lost in loss record 2,264 of 2,271
==689017==    at 0x484DA83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==689017==    by 0x56E7D7C: FrameInit (in /home/robi/Workspace_tof/libs/libtofi_compute.so)
==689017==    by 0x56E7FB9: InitTofiCompute (in /home/robi/Workspace_tof/libs/libtofi_compute.so)
==689017==    by 0x4C3DD21: CameraItof::initComputeLibrary() (camera_itof.cpp:1085)
==689017==    by 0x4C3B454: CameraItof::setFrameType(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (camera_itof.cpp:696)
==689017==    by 0x151A27: adiMainWindow::ADIMainWindow::prepareCamera(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (ADIMainWindow.cpp:1162)
==689017==    by 0x15200C: adiMainWindow::ADIMainWindow::PlayCCD(int, int) (ADIMainWindow.cpp:1209)
==689017==    by 0x14D7D4: adiMainWindow::ADIMainWindow::render() (ADIMainWindow.cpp:405)
==689017==    by 0x12EA70: main (ADIToF.cpp:88)
==689017== 
==689017== 1,048,576 bytes in 1 blocks are definitely lost in loss record 2,267 of 2,271
==689017==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==689017==    by 0x56FB55A: ConfigureCCBData (in /home/robi/Workspace_tof/libs/libtofi_config.so)
==689017==    by 0x56FBD16: InitTofiConfig_isp (in /home/robi/Workspace_tof/libs/libtofi_config.so)
==689017==    by 0x4C3DB75: CameraItof::initComputeLibrary() (camera_itof.cpp:1058)
==689017==    by 0x4C3B454: CameraItof::setFrameType(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (camera_itof.cpp:696)
==689017==    by 0x151A27: adiMainWindow::ADIMainWindow::prepareCamera(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (ADIMainWindow.cpp:1162)
==689017==    by 0x15200C: adiMainWindow::ADIMainWindow::PlayCCD(int, int) (ADIMainWindow.cpp:1209)
==689017==    by 0x14D7D4: adiMainWindow::ADIMainWindow::render() (ADIMainWindow.cpp:405)
==689017==    by 0x12EA70: main (ADIToF.cpp:88)
==689017== 
==689017== 2,097,152 bytes in 2 blocks are definitely lost in loss record 2,269 of 2,271
==689017==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==689017==    by 0x56FB542: ConfigureCCBData (in /home/robi/Workspace_tof/libs/libtofi_config.so)
==689017==    by 0x56FBD16: InitTofiConfig_isp (in /home/robi/Workspace_tof/libs/libtofi_config.so)
==689017==    by 0x4C3DB75: CameraItof::initComputeLibrary() (camera_itof.cpp:1058)
==689017==    by 0x4C3B454: CameraItof::setFrameType(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (camera_itof.cpp:696)
==689017==    by 0x151A27: adiMainWindow::ADIMainWindow::prepareCamera(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (ADIMainWindow.cpp:1162)
==689017==    by 0x15200C: adiMainWindow::ADIMainWindow::PlayCCD(int, int) (ADIMainWindow.cpp:1209)
==689017==    by 0x14D7D4: adiMainWindow::ADIMainWindow::render() (ADIMainWindow.cpp:405)
==689017==    by 0x12EA70: main (ADIToF.cpp:88)
==689017== 
==689017== 2,097,152 bytes in 2 blocks are definitely lost in loss record 2,270 of 2,271
==689017==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==689017==    by 0x56FB54E: ConfigureCCBData (in /home/robi/Workspace_tof/libs/libtofi_config.so)
==689017==    by 0x56FBD16: InitTofiConfig_isp (in /home/robi/Workspace_tof/libs/libtofi_config.so)
==689017==    by 0x4C3DB75: CameraItof::initComputeLibrary() (camera_itof.cpp:1058)
==689017==    by 0x4C3B454: CameraItof::setFrameType(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (camera_itof.cpp:696)
==689017==    by 0x151A27: adiMainWindow::ADIMainWindow::prepareCamera(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (ADIMainWindow.cpp:1162)
==689017==    by 0x15200C: adiMainWindow::ADIMainWindow::PlayCCD(int, int) (ADIMainWindow.cpp:1209)
==689017==    by 0x14D7D4: adiMainWindow::ADIMainWindow::render() (ADIMainWindow.cpp:405)
==689017==    by 0x12EA70: main (ADIToF.cpp:88)
==689017== 
==689017== 4,719,570 (64 direct, 4,719,506 indirect) bytes in 1 blocks are definitely lost in loss record 2,271 of 2,271
==689017==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==689017==    by 0x56E7F5F: InitTofiCompute (in /home/robi/Workspace_tof/libs/libtofi_compute.so)
==689017==    by 0x4C3DD21: CameraItof::initComputeLibrary() (camera_itof.cpp:1085)
==689017==    by 0x4C3B454: CameraItof::setFrameType(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (camera_itof.cpp:696)
==689017==    by 0x151A27: adiMainWindow::ADIMainWindow::prepareCamera(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (ADIMainWindow.cpp:1162)
==689017==    by 0x15200C: adiMainWindow::ADIMainWindow::PlayCCD(int, int) (ADIMainWindow.cpp:1209)
==689017==    by 0x14D7D4: adiMainWindow::ADIMainWindow::render() (ADIMainWindow.cpp:405)
==689017==    by 0x12EA70: main (ADIToF.cpp:88)
==689017== 
==689017== LEAK SUMMARY:
==689017==    definitely lost: 5,243,064 bytes in 8 blocks
==689017==    indirectly lost: 4,719,972 bytes in 12 blocks
==689017==      possibly lost: 3,146,160 bytes in 4 blocks
==689017==    still reachable: 261,980 bytes in 3,461 blocks
==689017==         suppressed: 0 bytes in 0 blocks
==689017== Reachable blocks (those to which a pointer was found) are not shown.
==689017== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==689017== 
==689017== For lists of detected and suppressed errors, rerun with: -s
==689017== ERROR SUMMARY: 144 errors from 42 contexts (suppressed: 0 from 0)
```