### PR TITLE
adi/depth-compute

### DIFF
--- a/sdk/common/adi/depth-compute-opensource/CMakeLists.txt
+++ b/sdk/common/adi/depth-compute-opensource/CMakeLists.txt
@@ -4,7 +4,7 @@ project(depth-compute-opensource)
 set (LIB_HEADERS "${CMAKE_SOURCE_DIR}/sdk/common/adi/tofi/")
 set (CCB_HEADERS "${CMAKE_SOURCE_DIR}/sdk/common/adi/ccb/include")
 
-add_library(tofi_compute SHARED src/tofiCompute.cpp src/opencv_undistort.cpp)
+add_library(tofi_compute SHARED src/tofiCompute.cpp ../tofi/opencv_undistort.cpp)
 target_include_directories(tofi_compute
     PUBLIC
         $<INSTALL_INTERFACE:include>


### PR DESCRIPTION
Correct path to opencv_undistort for opensource depth_compute