### PR TITLE
Fixed parser problem with multiple mandatory arguments

### DIFF
--- a/dependencies/adi/command_parser/command_parser.cpp
+++ b/dependencies/adi/command_parser/command_parser.cpp
@@ -45,11 +45,20 @@ void CommandParser::parseArguments(
         int contains_equal = std::string(argv[i]).find("=");
         for (int j = 0; j < arg_position.size(); j++) {
             if (arg_number == arg_position[j].second &&
-                (std::string(argv[i]).find("h") == -1 &&
-                 std::string(argv[i]).find("help") == -1)) {
-                m_command_vector.push_back({arg_position[j].first, argv[i]});
+                (std::string(argv[i]).find("-h") == -1 &&
+                 std::string(argv[i]).find("--help") == -1)) {
+                if (contains_equal != -1) {
+                    m_command_vector.push_back(
+                        {std::string(argv[i]).substr(0, contains_equal),
+                         std::string(argv[i]).substr(contains_equal + 1)});
+                } else {
+                    m_command_vector.push_back(
+                        {arg_position[j].first, argv[i + 1]});
+                    i++;
+                }
                 arg_number++;
                 mandatory = true;
+                break;
             }
         }
         if (mandatory) {


### PR DESCRIPTION
I found that when using multiple mandatory arguments, command parser will not store the [arguments, value] properly. This happened because of missing lines of code for handling these two case (for mandatory arguments):
- argument=value
- argument value