### PR TITLE
examples/viewer: Cleanup frame details before creating a new frame

### DIFF
--- a/examples/tof-viewer/src/ADIToFRecorder.cpp
+++ b/examples/tof-viewer/src/ADIToFRecorder.cpp
@@ -279,6 +279,8 @@ void ADIToFRecorder::playbackThread() {
 
         m_playbackCv.wait(lock, [&]() { return m_shouldReadNewFrame; });
         m_shouldReadNewFrame = false;
+        m_frameDetails.dataDetails.clear();
+
         dataDetails.type = "depth";
         dataDetails.width = m_frameDetails.width;
         dataDetails.height = m_frameDetails.height;


### PR DESCRIPTION
I observed this while playing back a recorded stream. The memory usage (seen in Visual Studio IDE) was constantly going up, reaching 4 GB in less than a minute.
After this fix, the memory usage remains around 800 MB but this value is not that important. What is important is the fact that memory usage no longer increases.