### PR TITLE
sdcard-images-utils/nxp/patches/linux-imx: Changed image pixel format to

### DIFF
--- a/sdcard-images-utils/nxp/patches/linux-imx/0057-drivers-media-i2c-adsd3500.c-Modified-image-pixel-fo.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0057-drivers-media-i2c-adsd3500.c-Modified-image-pixel-fo.patch
@@ -1,0 +1,153 @@
+From 21c28337cc62b4fc9234b231266d0e200d77f27f Mon Sep 17 00:00:00 2001
+From: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Thu, 16 Nov 2023 19:04:38 +0530
+Subject: [PATCH] drivers/media/i2c/adsd3500.c: Modified image pixel format to
+ RAW8
+
+Signed-off-by: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/i2c/adsd3500.c | 73 +++++++++++++++++++++++++-----------
+ 1 file changed, 51 insertions(+), 22 deletions(-)
+
+diff --git a/drivers/media/i2c/adsd3500.c b/drivers/media/i2c/adsd3500.c
+index e1b25b668550..36fea3193fd4 100644
+--- a/drivers/media/i2c/adsd3500.c
++++ b/drivers/media/i2c/adsd3500.c
+@@ -442,83 +442,112 @@ static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
+ 		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW16 MP 3 phase + 1 AB
++	{ //RAW8 MP 16BPP * 3 phase + 16BPP * 1 AB
+ 		.width = 2048,
+ 		.height = 4096,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW16 MP 3 phase
++	{ //RAW8 MP 16BPP * 3 phase
+ 		.width = 2048,
+ 		.height = 3072,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW16 QMP 3 phase + 1 AB
++	{ //RAW8 QMP 16BPP * 3 phase + 16BPP * 1 AB
+ 		.width = 1024,
+ 		.height = 2048,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW16 QMP 3 phase + 3 AB
++	{ //RAW8 QMP 16BPP * 3 phase + 16BPP * 3 AB
+ 		.width = 3072,
+ 		.height = 3072,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW16 QMP 3 phase
++	{ //RAW8 QMP 16BPP * 3 phase
+ 		.width = 1024,
+ 		.height = 1536,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW16 VGA 3 phase + 1 AB
++	{ //RAW8 VGA 16BPP * 3 phase + 16BPP * 1 AB
+ 		.width = 1024,
+ 		.height = 2560,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW16 VGA 3 phase + 3 AB
++	{ //RAW8 VGA 16BPP * 3 phase + 16BPP * 3 AB
+ 		.width = 3072,
+ 		.height = 3840,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW16 VGA 3 phase
++	{ //RAW8 VGA 16BPP * 3 phase
+ 		.width = 1024,
+ 		.height = 1920,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW16 QVGA 3 phase + 1 AB
++	{ //RAW8 QVGA 16BPP * 3 phase + 16BPP * 1 AB
+ 		.width = 512,
+ 		.height = 1920,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW16 QVGA 3 phase + 3 AB
++	{ //RAW8 QVGA 16BPP * 3 phase + 16BPP * 3 AB
+ 		.width = 1536,
+ 		.height = 1920,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
+-	{ //RAW16 QVGA 3 phase
++	{ //RAW8 QVGA 16BPP * 3 phase
+ 		.width = 512,
+ 		.height = 1280,
+ 		.pixel_rate = 488000000,
+-		.code = MEDIA_BUS_FMT_SBGGR16_1X16,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
++		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
++	},
++	{ //RAW8 ADSD3030 * 3 phase
++		.width = 1024,
++		.height = 2080,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
+ 		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
+ 	},
++	{ //RAW8 ADSD3030 16BPP
++		.width = 512,
++		.height = 1040,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
++		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
++	},
++	{ //RAW8 ADSD3030 16BPP
++		.width = 1024,
++		.height = 1664,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
++		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
++	},
++	{ //RAW8 ADSD3030 16BPP
++		.width = 1024,
++		.height = 1280,
++		.pixel_rate = 488000000,
++		.code = MEDIA_BUS_FMT_SBGGR8_1X8,
++		.link_freq_idx = 0 /* an index in link_freq_tbl[] */
++	},
++
+ };
+ 
+ static bool adsd3500_regmap_accessible_reg(struct device *dev, unsigned int reg)
+-- 
+2.28.0
+


### PR DESCRIPTION
Added RAW8 resolutions for ADSD3100 and ADSD3030 sensors.