### PR TITLE
depth-compute-opensource: Avoid crash when providing a null XYZ pointer

### DIFF
--- a/sdk/common/adi/depth-compute-opensource/src/tofiCompute.cpp
+++ b/sdk/common/adi/depth-compute-opensource/src/tofiCompute.cpp
@@ -126,12 +126,19 @@ int TofiCompute(const uint16_t *const input_frame,
         (uint16_t *)p_tofi_compute_context->p_conf_frame,
         p_tofi_compute_context->p_ab_frame);
 
-    // Compute Point cloud
-    Algorithms::ComputeXYZ(p_tofi_compute_context->p_depth_frame, &p->xyz_table,
-                           p_tofi_compute_context->p_xyz_frame, n_rows, n_cols);
-
     if (status != 0) {
-        std::cout << "Unable to compute XYZ !" << std::endl;
+        std::cout << "Unable to deinterleave frame data !" << std::endl;
+    }
+
+    // Compute Point cloud if needed (when a location address to XYZ is provided)
+    if (p_tofi_compute_context->p_xyz_frame) {
+        status = Algorithms::ComputeXYZ(
+            p_tofi_compute_context->p_depth_frame, &p->xyz_table,
+            p_tofi_compute_context->p_xyz_frame, n_rows, n_cols);
+
+        if (status != 0) {
+            std::cout << "Unable to compute XYZ !" << std::endl;
+        }
     }
 
     return 0;


### PR DESCRIPTION
Depth compute considers that if a null pointer is provided for XYZ, it will just not produce point cloud. Therefore, we do the same for the open source implementation of depth compute.