### PR TITLE
sdk: Fix setting confidence to half size

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -571,6 +571,8 @@ aditof::Status CameraItof::setFrameType(const std::string &frameType) {
             fDataDetails.subelementSize = 1;
             fDataDetails.width = 128;
             fDataDetails.height = 1;
+        } else if (item.type == "conf") {
+            fDataDetails.subelementSize = sizeof(float);
         }
         fDataDetails.bytesCount = fDataDetails.width * fDataDetails.height *
                                   fDataDetails.subelementSize *


### PR DESCRIPTION
Confidence data is comming from target as float (each pixel is a float).