### PR TITLE
sdk/network: Don't lock mutex on the lws callback

### DIFF
--- a/sdk/src/connections/network/network.cpp
+++ b/sdk/src/connections/network/network.cpp
@@ -427,7 +427,6 @@ int Network::callback_function(struct lws *wsi,
 #ifdef NW_DEBUG
         cout << endl << "Rcvd Data len : " << len << endl;
 #endif
-        std::lock_guard<std::mutex> guard(mutex_recv[connectionId]);
 
         const size_t remaining = lws_remaining_packet_payload(wsi);
         bool isFinal = lws_is_final_fragment(wsi);
@@ -496,7 +495,6 @@ int Network::callback_function(struct lws *wsi,
 #ifdef NW_DEBUG
         cout << endl << "Client is sending " << send_buff.func_name() << endl;
 #endif
-        std::lock_guard<std::recursive_mutex> guard(m_mutex[connectionId]);
         if (send_buff[connectionId].func_name().empty()) {
             break;
         }


### PR DESCRIPTION
The issue was that sometimes (depends on how fast the lws callback gets called) a deadlock (with 10 seconds timeout) would appear, making a certain command to be send to server to timeout.

There is one thread (usually main thread) where SendCommand() calls are being made. One the 1st things that SendCommand() does is to call lws_callback_on_writable() which triggers (or schedules) the callback_function() to be called. This doesn't happen instantly (could take longer or right away). This callback is executed on another thread (which is the thread where we execute call_lws_service() in a loop. Now, getting back to the SendCommand(), which has just triggered the callback to be called ASAP but then it locks the m_mutex and if it does that before the callback_function() gets called, the callback will block because it also try to lock the m_mutex (see case
LWS_CALLBACK_CLIENT_WRITABLE). Then SendCommand() waits for callback to finish or until 10 seconds had passed away. Since callback is blocked, SendCommand() will timeout.
This doesn't happend each time. The most frequent scenario is when callback is called really quickly and has the chance to lock the m_mutex first, then sends data to server while SendCommand() remains blocked trying to lock the m_mutex and then remains blocked waiting for the callback to end which might already happened.
Also, do the same for the recv_server_data().
These changes were here from the beginning. I am not sure about their purpose and by removing them I can't see the drawbacks. At least not yet.