### PR TITLE
scripts/nxp: Update cmake options

### DIFF
--- a/scripts/nxp/setup.sh
+++ b/scripts/nxp/setup.sh
@@ -129,7 +129,7 @@ setup() {
         build_and_install_protobuf ${deps_dir}/protobuf ${deps_install_dir}/protobuf
         build_and_install_websockets ${deps_dir}/libwebsockets ${deps_install_dir}/websockets
 
-        CMAKE_OPTIONS="-DNXP=1 -DUSE_DEPTH_COMPUTE_OPENSOURCE=1 -DWITH_NETWORK=1 -DWITH_PYTHON=1"
+        CMAKE_OPTIONS="-DNXP=1 -DWITH_PYTHON=1"
         PREFIX_PATH="${deps_install_dir}/glog;${deps_install_dir}/protobuf;${deps_install_dir}/websockets;"
 
         pushd "${build_dir}"


### PR DESCRIPTION
Network is enabled by default so no need to pass that again to cmake. On NXP, by default, we want to use the closed source depth compute.