### PR TITLE
Removing deltaCompEnable and absumThresh from INI parameters since they are not used

### DIFF
--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_lr-mixed.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_lr-mixed.ini
@@ -1,5 +1,4 @@
 abThreshMin=1.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=100.0
 radialThreshMax=10000.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=128
-deltaCompEnable=0
 inputFormat=raw8
 depthComputeIspEnable=1
 partialDepthEnable=0

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_lr-native.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_lr-native.ini
@@ -18,4 +18,4 @@ bitsInConf=8
 bitsInAB=16
 phaseInvalid=0
 xyzEnable=1
-fps=40
+fps=16

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_lr-native.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_lr-native.ini
@@ -1,5 +1,4 @@
 abThreshMin=3.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=100.0
 radialThreshMax=10000.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=128
-deltaCompEnable=0
 inputFormat=raw8
 depthComputeIspEnable=1
 partialDepthEnable=0

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_lr-qnative.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_lr-qnative.ini
@@ -1,5 +1,4 @@
 abThreshMin=3.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=100.0
 radialThreshMax=10000.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=128
-deltaCompEnable=0
 inputFormat=raw8
 depthComputeIspEnable=1
 partialDepthEnable=0

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_sr-mixed.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_sr-mixed.ini
@@ -1,5 +1,4 @@
 abThreshMin=1.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=100.0
 radialThreshMax=10000.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=128
-deltaCompEnable=0
 inputFormat=raw8
 depthComputeIspEnable=1
 partialDepthEnable=0

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_sr-native.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_sr-native.ini
@@ -18,4 +18,4 @@ bitsInConf=8
 bitsInAB=16
 phaseInvalid=0
 xyzEnable=1
-fps=40
+fps=16

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_sr-native.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_sr-native.ini
@@ -1,5 +1,4 @@
 abThreshMin=3.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=100.0
 radialThreshMax=10000.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=128
-deltaCompEnable=0
 inputFormat=raw8
 depthComputeIspEnable=1
 partialDepthEnable=0

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_sr-qnative.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3030_sr-qnative.ini
@@ -1,5 +1,4 @@
 abThreshMin=3.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=100.0
 radialThreshMax=10000.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=128
-deltaCompEnable=0
 inputFormat=raw8
 depthComputeIspEnable=1
 partialDepthEnable=0

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_lr-mixed.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_lr-mixed.ini
@@ -18,4 +18,4 @@ bitsInConf=8
 bitsInAB=16
 phaseInvalid=0
 xyzEnable=1
-fps=40
+fps=16

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_lr-mixed.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_lr-mixed.ini
@@ -1,5 +1,4 @@
 abThreshMin=1.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=50.0
 radialThreshMax=15000.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=128
-deltaCompEnable=0
 inputFormat=raw8
 depthComputeIspEnable=1
 partialDepthEnable=0

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_lr-native.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_lr-native.ini
@@ -1,5 +1,4 @@
 abThreshMin=3.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=50.0
 radialThreshMax=15000.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=128
-deltaCompEnable=0
 inputFormat=mipiRaw12_8
 depthComputeIspEnable=1
 partialDepthEnable=1

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_lr-native.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_lr-native.ini
@@ -18,4 +18,4 @@ bitsInConf=0
 bitsInAB=16
 phaseInvalid=0
 xyzEnable=1
-fps=20
+fps=10

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_lr-qnative.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_lr-qnative.ini
@@ -1,5 +1,4 @@
 abThreshMin=3.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=50.0
 radialThreshMax=15000.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=128
-deltaCompEnable=0
 inputFormat=raw8
 depthComputeIspEnable=1
 partialDepthEnable=0

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_lr-qnative.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_lr-qnative.ini
@@ -18,4 +18,4 @@ bitsInConf=8
 bitsInAB=16
 phaseInvalid=0
 xyzEnable=1
-fps=40
+fps=16

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_sr-mixed.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_sr-mixed.ini
@@ -18,4 +18,4 @@ bitsInConf=8
 bitsInAB=16
 phaseInvalid=0
 xyzEnable=1
-fps=40
+fps=16

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_sr-mixed.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_sr-mixed.ini
@@ -1,5 +1,4 @@
 abThreshMin=1.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=30.0
 radialThreshMax=4200.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=128
-deltaCompEnable=0
 inputFormat=raw8
 depthComputeIspEnable=1
 partialDepthEnable=0

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_sr-native.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_sr-native.ini
@@ -1,5 +1,4 @@
 abThreshMin=3.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=30.0
 radialThreshMax=4200.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=128
-deltaCompEnable=0
 inputFormat=mipiRaw12_8
 depthComputeIspEnable=1
 partialDepthEnable=1

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_sr-native.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_sr-native.ini
@@ -18,4 +18,4 @@ bitsInConf=0
 bitsInAB=16
 phaseInvalid=0
 xyzEnable=1
-fps=20
+fps=10

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_sr-qnative.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_sr-qnative.ini
@@ -18,4 +18,4 @@ bitsInConf=8
 bitsInAB=16
 phaseInvalid=0
 xyzEnable=1
-fps=40
+fps=16

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_sr-qnative.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd3500_sr-qnative.ini
@@ -1,5 +1,4 @@
 abThreshMin=3.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=30.0
 radialThreshMax=4200.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=128
-deltaCompEnable=0
 inputFormat=raw8
 depthComputeIspEnable=1
 partialDepthEnable=0

--- a/sdk/src/cameras/itof-camera/config/RawToDepthAdsd_pcm-native.ini
+++ b/sdk/src/cameras/itof-camera/config/RawToDepthAdsd_pcm-native.ini
@@ -1,5 +1,4 @@
 abThreshMin=3.0
-abSumThresh=25.0
 confThresh=25.0
 radialThreshMin=100.0
 radialThreshMax=10000.0
@@ -10,7 +9,6 @@ jblfExponentialTerm=5.0
 jblfMaxEdge=12.0
 jblfABThreshold=10.0
 headerSize=0
-deltaCompEnable=0
 inputFormat=mipiRaw12_8
 depthComputeIspEnable=0
 partialDepthEnable=0


### PR DESCRIPTION
DeltaCompEnabled and absumThresh are removed from the INI parameters list since they are not used.