### PR TITLE
lws_callback_on_writeable() call must be called twice

### DIFF
--- a/sdk/src/connections/network/network.cpp
+++ b/sdk/src/connections/network/network.cpp
@@ -247,6 +247,7 @@ int Network::SendCommand(void *rawPayload) {
            Server_Connected[m_connectionId] != false) {
 
         lws_callback_on_writable(web_socket.at(m_connectionId));
+        lws_callback_on_writable(web_socket.at(m_connectionId));
         /*Acquire the lock*/
         std::unique_lock<std::recursive_mutex> mlock(m_mutex[m_connectionId]);
 


### PR DESCRIPTION
The entire streaming on network is more stable on NVidia as host if we call the libwebsockets service routing twice when sending a command to server.
More specifically, this fixes the issue where, from time to time, the video streaming stops due to a 10s timeout then starts again.