### PR TITLE
examples/viewer: Check whether modal popup was created or not

### DIFF
--- a/examples/tof-viewer/src/ADIMainWindow.cpp
+++ b/examples/tof-viewer/src/ADIMainWindow.cpp
@@ -2599,8 +2599,10 @@ int ADIMainWindow::saveIniFile() {
 }
 
 void ADIMainWindow::iniParamWarn(std::string variable, std::string validVal) {
-    ImGui::BeginPopupModal("Error", NULL, ImGuiWindowFlags_AlwaysAutoResize);
-    ImGui::Text("Invalid %s value.", variable.c_str());
-    ImGui::Text(validVal.c_str());
-    ImGui::EndPopup();
+    if (ImGui::BeginPopupModal("Error", NULL,
+                               ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::Text("Invalid %s value.", variable.c_str());
+        ImGui::Text(validVal.c_str());
+        ImGui::EndPopup();
+    }
 }


### PR DESCRIPTION
This prevents crash when ImGui::End() is called for a popup that couldn't be created. At this point in time I don't know the reasons for why popup can't be created.