### PR TITLE
scripts/nxp: By default build with opensouce depth compute

### DIFF
--- a/scripts/nxp/setup.sh
+++ b/scripts/nxp/setup.sh
@@ -129,7 +129,7 @@ setup() {
         build_and_install_protobuf ${deps_dir}/protobuf ${deps_install_dir}/protobuf
         build_and_install_websockets ${deps_dir}/libwebsockets ${deps_install_dir}/websockets
 
-        CMAKE_OPTIONS="-DNXP=1 -DWITH_PYTHON=1"
+        CMAKE_OPTIONS="-DNXP=1 -DUSE_DEPTH_COMPUTE_OPENSOURCE=ON -DWITH_PYTHON=1"
         PREFIX_PATH="${deps_install_dir}/glog;${deps_install_dir}/protobuf;${deps_install_dir}/websockets;"
 
         pushd "${build_dir}"


### PR DESCRIPTION
This is to make it easier for the process of creating the SD card image.