### PR TITLE
sdk/CMakeLists: update variable

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -201,7 +201,7 @@ if ( ON_TARGET AND UNIX )
 endif()	
 
 
-if (CMAKE_COMPILER_IS_GNUCC)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(${PROJECT_NAME} PUBLIC
             -Wall
             -Wno-unknown-pragmas


### PR DESCRIPTION
Due to deprecated CMAKE_COMPILER_IS_GNUCC change to CMAKE_CXX_COMPILER_ID
