### PR TITLE
examples/viewer: Fix not being able to playback more than 200 frames

### DIFF
--- a/examples/tof-viewer/include/ADIToFRecorder.h
+++ b/examples/tof-viewer/include/ADIToFRecorder.h
@@ -173,10 +173,10 @@ class ADIToFRecorder {
     bool m_saveBinaryFormat = false;
     bool m_finishRecording = true;
     bool _stopPlayback = false;
-    int currentPBPos = 0;
+    size_t currentPBPos = 0;
     int totalBits = 0;
     int m_numberOfFrames;
-    int fileSize = 0;
+    size_t fileSize = 0;
     uint16_t m_sizeOfHeader;
 
   private:

--- a/examples/tof-viewer/src/ADIMainWindow.cpp
+++ b/examples/tof-viewer/src/ADIMainWindow.cpp
@@ -1704,7 +1704,7 @@ void ADIMainWindow::displayInfoWindow(ImGuiWindowFlags overlayFlags) {
                 "Progress", &rawSeeker, 0,
                 (view->m_ctrl->m_recorder->m_numberOfFrames) - 1, "%d", true);
             view->m_ctrl->m_recorder->currentPBPos =
-                rawSeeker *
+                size_t(rawSeeker) *
                     (((int)view->m_ctrl->m_recorder->m_frameDetails.height) *
                          ((int)view->m_ctrl->m_recorder->m_frameDetails.width) *
                          (view->m_ctrl->m_recorder->totalBits) +

--- a/examples/tof-viewer/src/ADIToFRecorder.cpp
+++ b/examples/tof-viewer/src/ADIToFRecorder.cpp
@@ -164,7 +164,7 @@ int ADIToFRecorder::startPlaybackRaw(const std::string &fileName, int &fps) {
         width = m_metadataStruct.width;
     }
 
-    int sizeOfFrame = height * width * totalBits;
+    size_t sizeOfFrame = height * width * totalBits;
     currentPBPos = m_sizeOfHeader;
     m_numberOfFrames = fileSize / (m_sizeOfHeader + sizeOfFrame);
 


### PR DESCRIPTION
Seems that when file size is large, several variables of type int will overflow. This happens when recording 'lr-native' (1024x1024) and more than 200 frames (205) to be precise.
Use size_t which should contain 8 bytes of unsinged integer. This should handle situations with larger files.
Files can't be infinite large since viewer has a upper limit of 300 frames to record.