### PR TITLE
On target make offline use depth compute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,20 @@ if (WITH_OFFLINE)
                         file(DOWNLOAD "${MODE_URL}" "${MODE_PATH}")
                 endif()
         endforeach()
+
+        if (ON_TARGET)
+                make_directory("${RESOURCES_OFFLINE_DIR}/adsd3500_raw")
+
+                message("Downloading raw frames into ${RESOURCES_OFFLINE_DIR}/adsd3500_raw")
+                foreach(MODE IN LISTS MODE_FILE)
+                set(MODE_URL "swdownloads.analog.com/cse/aditof/resources/itof/offline/adsd3500_raw/${MODE}")
+                set(MODE_PATH "${RESOURCES_OFFLINE_DIR}/adsd3500_raw/${MODE}")
+
+                if (NOT EXISTS ${MODE_PATH})
+                        file(DOWNLOAD "${MODE_URL}" "${MODE_PATH}")
+                endif()
+        endforeach()
+        endif()
 endif()
 
 if(WITH_GLOG_DEPENDENCY)

--- a/sdk/src/connections/offline/offline_depth_sensor.cpp
+++ b/sdk/src/connections/offline/offline_depth_sensor.cpp
@@ -248,55 +248,90 @@ aditof::Status OfflineDepthSensor::adsd3500_read_payload_cmd(
         if (readback_data[0] == 0) {
             dealiasStruct.n_rows = 1024;
             dealiasStruct.n_cols = 1024;
+            dealiasStruct.n_freqs = 2;
             dealiasStruct.row_bin_factor = 1;
             dealiasStruct.col_bin_factor = 1;
             dealiasStruct.n_sensor_rows = 1024;
             dealiasStruct.n_sensor_cols = 1024;
+            dealiasStruct.FreqIndex[0] = 1;
+            dealiasStruct.FreqIndex[1] = 2;
+            dealiasStruct.FreqIndex[2] = 0;
+            dealiasStruct.Freq[0] = 14200;
+            dealiasStruct.Freq[1] = 17750;
+            dealiasStruct.Freq[2] = 0;
         } else if (readback_data[0] == 1) {
             dealiasStruct.n_rows = 1024;
             dealiasStruct.n_cols = 1024;
+            dealiasStruct.n_freqs = 3;
             dealiasStruct.row_bin_factor = 1;
             dealiasStruct.col_bin_factor = 1;
             dealiasStruct.n_sensor_rows = 1024;
             dealiasStruct.n_sensor_cols = 1024;
+            dealiasStruct.FreqIndex[0] = 1;
+            dealiasStruct.FreqIndex[1] = 2;
+            dealiasStruct.FreqIndex[2] = 3;
+            dealiasStruct.Freq[0] = 19800;
+            dealiasStruct.Freq[1] = 18900;
+            dealiasStruct.Freq[2] = 5400;
         } else if (readback_data[0] == 2) {
             dealiasStruct.n_rows = 512;
             dealiasStruct.n_cols = 512;
+            dealiasStruct.n_freqs = 2;
             dealiasStruct.row_bin_factor = 1;
             dealiasStruct.col_bin_factor = 1;
             dealiasStruct.n_sensor_rows = 1024;
             dealiasStruct.n_sensor_cols = 1024;
+            dealiasStruct.FreqIndex[0] = 1;
+            dealiasStruct.FreqIndex[1] = 2;
+            dealiasStruct.FreqIndex[2] = 0;
+            dealiasStruct.Freq[0] = 14200;
+            dealiasStruct.Freq[1] = 17750;
+            dealiasStruct.Freq[2] = 0;
         } else if (readback_data[0] == 3) {
             dealiasStruct.n_rows = 512;
             dealiasStruct.n_cols = 512;
+            dealiasStruct.n_freqs = 3;
             dealiasStruct.row_bin_factor = 1;
             dealiasStruct.col_bin_factor = 1;
             dealiasStruct.n_sensor_rows = 1024;
             dealiasStruct.n_sensor_cols = 1024;
+            dealiasStruct.FreqIndex[0] = 1;
+            dealiasStruct.FreqIndex[1] = 2;
+            dealiasStruct.FreqIndex[2] = 3;
+            dealiasStruct.Freq[0] = 19800;
+            dealiasStruct.Freq[1] = 18900;
+            dealiasStruct.Freq[2] = 5400;
         } else if (readback_data[0] == 5) {
             dealiasStruct.n_rows = 512;
             dealiasStruct.n_cols = 512;
+            dealiasStruct.n_freqs = 3;
             dealiasStruct.row_bin_factor = 1;
             dealiasStruct.col_bin_factor = 1;
             dealiasStruct.n_sensor_rows = 1024;
             dealiasStruct.n_sensor_cols = 1024;
+            dealiasStruct.FreqIndex[0] = 1;
+            dealiasStruct.FreqIndex[1] = 2;
+            dealiasStruct.FreqIndex[2] = 3;
+            dealiasStruct.Freq[0] = 19800;
+            dealiasStruct.Freq[1] = 18900;
+            dealiasStruct.Freq[2] = 5400;
         } else if (readback_data[0] == 6) {
             dealiasStruct.n_rows = 512;
             dealiasStruct.n_cols = 512;
+            dealiasStruct.n_freqs = 2;
             dealiasStruct.row_bin_factor = 1;
             dealiasStruct.col_bin_factor = 1;
             dealiasStruct.n_sensor_rows = 1024;
             dealiasStruct.n_sensor_cols = 1024;
+            dealiasStruct.FreqIndex[0] = 1;
+            dealiasStruct.FreqIndex[1] = 2;
+            dealiasStruct.FreqIndex[2] = 0;
+            dealiasStruct.Freq[0] = 14200;
+            dealiasStruct.Freq[1] = 17750;
+            dealiasStruct.Freq[2] = 0;
         }
-        dealiasStruct.n_freqs = 2;
         dealiasStruct.n_offset_rows = 0;
         dealiasStruct.n_offset_cols = 0;
-        dealiasStruct.FreqIndex[0] = 1;
-        dealiasStruct.FreqIndex[1] = 2;
-        dealiasStruct.FreqIndex[2] = 0;
-        dealiasStruct.Freq[0] = 14200;
-        dealiasStruct.Freq[1] = 17750;
-        dealiasStruct.Freq[2] = 0;
         memcpy(readback_data, &dealiasStruct,
                sizeof(TofiXYZDealiasData) - sizeof(CameraIntrinsics));
     } else {

--- a/sdk/src/connections/offline/offline_depth_sensor.h
+++ b/sdk/src/connections/offline/offline_depth_sensor.h
@@ -3,6 +3,11 @@
 
 #include "aditof/depth_sensor_interface.h"
 #include "aditof/sensor_definitions.h"
+#ifdef TARGET
+#include "tofi/tofi_compute.h"
+#include "tofi/tofi_config.h"
+#include "tofi/tofi_util.h"
+#endif
 
 #include <map>
 #include <memory>
@@ -145,6 +150,13 @@ class OfflineDepthSensor : public aditof::DepthSensorInterface {
             2560,
             512,
         }};
+#ifdef TARGET
+    TofiConfig *m_tofiConfig;
+    TofiComputeContext *m_tofiComputeContext;
+    TofiXYZDealiasData m_xyzDealiasData[11];
+    uint16_t m_outputFrameWidth;
+    uint16_t m_outputFrameHeight;
+#endif `
 };
 
 #endif // OFFLINE_DEPTH_SENSOR_H

--- a/sdk/src/connections/offline/offline_sensor_enumerator.cpp
+++ b/sdk/src/connections/offline/offline_sensor_enumerator.cpp
@@ -2,8 +2,13 @@
 #include "offline_depth_sensor.h"
 
 OfflineSensorEnumerator::OfflineSensorEnumerator() {
-    m_sensorsInfo.emplace_back(
-        std::string(std::string(RESOURCES) + "/offline"));
+#if TARGET
+    std::string pathToFrames =
+        std::string(RESOURCES) + std::string("/offline/adsd3500_raw");
+#else
+    std::string pathToFrames = std::string(RESOURCES) + std::string("/offline");
+#endif
+    m_sensorsInfo.emplace_back(pathToFrames);
 }
 
 aditof::Status OfflineSensorEnumerator::getDepthSensors(


### PR DESCRIPTION
The changes in this PR will allow users to evaluate depth compute on target (the embedded system to which the TOF camera is connected to) without hardware. A frame content will be available (as a binary file) to be passed through depth compute.

Things left to do:
 - test this with a binary file
 - upload the binary file to a server and make cmake download it