### PR TITLE
Add Nvidia CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,12 @@ jobs:
         DOCKER: "septimiuvana/tof-imx8-docker"
         EXTRA_CMAKE_FLAGS: "-DNXP=1"
 
+      #NVIDIA
+      ubuntu_20_04_nvidia:
+        imageName: 'ubuntu-20.04'
+        DOCKER: "adismartcamtest/tof_nvidia:4.0"
+        EXTRA_CMAKE_FLAGS: "-DNVIDIA=1"
+      
       #code quality, TO DO: once entire code is formatted enable clang-format
       clang_format:
         imageName: 'ubuntu-22.04'

--- a/ci/azure/nvidia-docker/Dockerfile
+++ b/ci/azure/nvidia-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/l4t-base:r32.4.3
+FROM nvcr.io/nvidia/l4t-base:r35.2.0
 # LABEL io.balena.architecture="aarch64"
  
 # LABEL io.balena.qemu.version="5.2.0+balena-aarch64"

--- a/ci/azure/readme.md
+++ b/ci/azure/readme.md
@@ -1,0 +1,18 @@
+# Useful scripts
+* Building cross platform docker images with limited memory usage:
+```console
+sudo docker buildx build -m 2g --output=type=docker --memory-swap
+2g -t <tag_name> --platform linux/arm64/v8 .
+```
+
+* Run interactive mode for cross platform docker images
+```console
+sudo docker run -v /bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-
+static --platform linux/arm64/v8 -it <docker_image_name> bash
+```
+
+* Tag images 
+```console
+docker image tag <old_name:latest> <new_name:latest>
+```
+


### PR DESCRIPTION
Adding Nvidia CI based on Jetson Linux 35.1.0 docker image, it contains:
* Kernel 5.10
* Ubuntu 20.04 Root File System