### PR TITLE
sdk: Support loading the DMS configuration from .json file

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -501,6 +501,24 @@ aditof::Status CameraItof::setMode(const uint8_t &mode) {
         }
     }
 
+    // If a Dynamic Mode Switching sequences has been loaded from config file then configure ADSD3500
+    if (m_configDmsSequence.size() > 0) {
+        status = this->adsd3500setEnableDynamicModeSwitching(true);
+        if (status != Status::OK) {
+            LOG(WARNING) << "Could not enable 'Dynamic Mode Switching.";
+            return status;
+        }
+
+        status =
+            this->adsds3500setDynamicModeSwitchingSequence(m_configDmsSequence);
+        m_configDmsSequence.clear();
+        if (status != Status::OK) {
+            LOG(WARNING)
+                << "Could not set a sequence for the 'Dynamic Mode Switching'.";
+            return status;
+        }
+    }
+
     return status;
 }
 
@@ -1426,6 +1444,26 @@ CameraItof::loadDepthParamsFromJsonFile(const std::string &pathFile,
             double errata1val = 1;
             if (cJSON_IsNumber(errata1)) {
                 errata1val = errata1->valuedouble;
+            }
+
+            cJSON *dmsSequence = cJSON_GetObjectItemCaseSensitive(
+                depthParams, "dynamicModeSwitching");
+            if (cJSON_IsArray(dmsSequence)) {
+
+                m_configDmsSequence.clear();
+
+                cJSON *dmsPair;
+                cJSON_ArrayForEach(dmsPair, dmsSequence) {
+                    cJSON *dmsMode =
+                        cJSON_GetObjectItemCaseSensitive(dmsPair, "mode");
+                    cJSON *dmsRepeat =
+                        cJSON_GetObjectItemCaseSensitive(dmsPair, "repeat");
+
+                    if (cJSON_IsNumber(dmsMode) && cJSON_IsNumber(dmsRepeat)) {
+                        m_configDmsSequence.emplace_back(std::make_pair(
+                            dmsMode->valueint, dmsRepeat->valueint));
+                    }
+                }
             }
 
             cJSON *depthframeType = cJSON_GetObjectItemCaseSensitive(

--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -261,6 +261,7 @@ class CameraItof : public aditof::Camera {
     aditof::ImagerType m_imagerType;
     bool m_dropFirstFrame;
     bool m_dropFrameOnce;
+    std::vector<std::pair<uint8_t, uint8_t>> m_configDmsSequence;
 };
 
 #endif // CAMERA_ITOF_H


### PR DESCRIPTION
Example of how the config file should be filled:

```
"depthParams": {
		"errata1": 1,
		"dynamicModeSwitching": [
			{
				"mode": 2,
				"repeat": 3
			},
			{
				"mode": 3,
				"repeat": 1
			}
		],
		"0": {
```