### PR TITLE
Solved stop button not working after first stream

### DIFF
--- a/examples/tof-viewer/include/ADIMainWindow.h
+++ b/examples/tof-viewer/include/ADIMainWindow.h
@@ -545,6 +545,7 @@ class ADIMainWindow {
 
     std::shared_ptr<adicontroller::ADIController> m_controller;
 
+    bool m_focusedOnce = false;
     bool m_skipNetworkCameras;
     std::string m_cameraIp;
     std::vector<std::pair<int, std::string>> m_configFiles;

--- a/examples/tof-viewer/src/ADIMainWindow.cpp
+++ b/examples/tof-viewer/src/ADIMainWindow.cpp
@@ -935,6 +935,7 @@ void ADIMainWindow::PlayRecorded() {
 }
 
 void ADIMainWindow::stopPlayCCD() {
+    m_focusedOnce = false;
     captureSeparateEnabled = true;
     captureBlendedEnabled = true;
     setABWinPositionOnce = true;
@@ -1810,6 +1811,10 @@ void ADIMainWindow::displayDepthWindow(ImGuiWindowFlags overlayFlags) {
     std::string title =
         "Depth"; //std::format("Depth: {} x {}", static_cast<uint32_t>(view->frameWidth), static_cast<uint32_t>(view->frameWidth));
     if (ImGui::Begin(title.c_str(), nullptr, overlayFlags)) {
+        if (!m_focusedOnce) {
+            ImGui::SetWindowFocus();
+            m_focusedOnce = true;
+        }
         ImVec2 hoveredImagePixel = InvalidHoveredPixel;
         GetHoveredImagePix(hoveredImagePixel, ImGui::GetCursorScreenPos(),
                            ImGui::GetIO().MousePos, displayDepthDimensions);


### PR DESCRIPTION
Stop button is working properly when streaming for the first time in ToF-viewer. After pressing the play button for a second time, the application remains focused on the "Open" menu. This will result in the need of two clicks to stop the stream (one to focus on the main panel and one for the stop button action).

To solve this, depth compute panel will be always focused when pressing the "play" button for streaming.

Same fix can be found in dev-5.1.0: https://github.com/analogdevicesinc/ToF/pull/669