### PR TITLE
Changed name of saved frames when recording

### DIFF
--- a/examples/tof-viewer/src/ADIMainWindow.cpp
+++ b/examples/tof-viewer/src/ADIMainWindow.cpp
@@ -531,7 +531,8 @@ void ADIMainWindow::showRecordMenu() {
 #endif
                 strftime(time_buffer, sizeof(time_buffer), "%Y%m%d%H%M",
                          &timeinfo);
-                tempPath += "\\frames" + std::string(time_buffer);
+                tempPath += "\\mode_" + std::to_string(modeSelection) +
+                            "_frames" + std::string(time_buffer);
 
                 int filterIndex = 0;
                 char tempbuff[MAX_PATH];


### PR DESCRIPTION
When recording, the name of the file will be the following: "mode_modeNr_frames_time.bin"