### PR TITLE
Changed window focus from depth to info window

### DIFF
--- a/examples/tof-viewer/src/ADIMainWindow.cpp
+++ b/examples/tof-viewer/src/ADIMainWindow.cpp
@@ -1522,6 +1522,11 @@ void ADIMainWindow::displayInfoWindow(ImGuiWindowFlags overlayFlags) {
 
     if (ImGui::Begin("Information Window", nullptr,
                      overlayFlags | ImGuiWindowFlags_NoTitleBar)) {
+
+        if (!m_focusedOnce) {
+            ImGui::SetWindowFocus();
+            m_focusedOnce = true;
+        }
         char formattedIP[20];
         for (int i = 0; i < m_cameraIp.length(); i++)
             formattedIP[i] = toupper(m_cameraIp[i]);
@@ -1812,10 +1817,6 @@ void ADIMainWindow::displayDepthWindow(ImGuiWindowFlags overlayFlags) {
     std::string title =
         "Depth"; //std::format("Depth: {} x {}", static_cast<uint32_t>(view->frameWidth), static_cast<uint32_t>(view->frameWidth));
     if (ImGui::Begin(title.c_str(), nullptr, overlayFlags)) {
-        if (!m_focusedOnce) {
-            ImGui::SetWindowFocus();
-            m_focusedOnce = true;
-        }
         ImVec2 hoveredImagePixel = InvalidHoveredPixel;
         GetHoveredImagePix(hoveredImagePixel, ImGui::GetCursorScreenPos(),
                            ImGui::GetIO().MousePos, displayDepthDimensions);


### PR DESCRIPTION
Now for every when streaming, information window will be focused. This solves the PCM and Point Cloud cases, where there is no depth window and stop streaming button needs to be pressed two times to work.