### PR TITLE
Cmake: change versioning name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,14 +56,14 @@ if (GIT_FOUND)
 		execute_process(
 			COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
 			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-			OUTPUT_VARIABLE ADITOFSDK_GIT_BRANCH
+			OUTPUT_VARIABLE TOFSDK_GIT_BRANCH
 			OUTPUT_STRIP_TRAILING_WHITESPACE
 		)
 	endif()
 endif()
 
-add_definitions(-DADITOFSDK_GIT_COMMIT="${ADITOFSDK_GIT_COMMIT}")
-add_definitions(-DADITOFSDK_GIT_BRANCH="${ADITOFSDK_GIT_BRANCH}")
+add_definitions(-DTOFSDK_GIT_COMMIT="${TOFSDK_GIT_COMMIT}")
+add_definitions(-DTOFSDK_GIT_BRANCH="${TOFSDK_GIT_BRANCH}")
 
 ############################## Rest of cmake ##################################
 

--- a/cmake/version.h.cmakein
+++ b/cmake/version.h.cmakein
@@ -43,8 +43,8 @@
 
 namespace aditof {
     static inline const std::string getApiVersion() { return std::string(ADITOF_API_VERSION); }
-    static inline const std::string getBranchVersion() { return std::string("@ADITOFSDK_GIT_BRANCH@"); }
-    static inline const std::string getCommitVersion() { return std::string("@ADITOFSDK_GIT_COMMIT@"); }
+    static inline const std::string getBranchVersion() { return std::string("@TOFSDK_GIT_BRANCH@"); }
+    static inline const std::string getCommitVersion() { return std::string("@TOFSDK_GIT_COMMIT@"); }
 } // namespace aditof
 
 #endif // VERSION_H


### PR DESCRIPTION
Since libaditof has been separated from examples, we have to keep different namings for versioning in order to avoid redefines and proper version control