### PR TITLE
update libaditof to set the metadata to 0 to eliminate its impact onscaling the AB image.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 ############################### Version #######################################
 set(ADITOF_VERSION_MAJOR 6)
 set(ADITOF_VERSION_MINOR 0)
-set(ADITOF_VERSION_PATCH 0)
+set(ADITOF_VERSION_PATCH 1)
 
 set(VERSION "${ADITOF_VERSION_MAJOR}.${ADITOF_VERSION_MINOR}.${ADITOF_VERSION_PATCH}")
 


### PR DESCRIPTION

This bug resulted in improper scaling that was obvious under dark conditions. 