### PR TITLE
Fix raw frame capture

### DIFF
--- a/drivers/adsd3500/nxp/src/i2c/adsd3500.c
+++ b/drivers/adsd3500/nxp/src/i2c/adsd3500.c
@@ -1188,7 +1188,7 @@ static int adsd3500_set_format(struct v4l2_subdev *sd,
 
 	framefmt->width = crop->width;
 	framefmt->height = crop->height;
-	framefmt->code = new_mode->code;
+	framefmt->code = format->format.code;
 	framefmt->field = V4L2_FIELD_NONE;
 	framefmt->colorspace = V4L2_COLORSPACE_RAW;
 

--- a/drivers/adsd3500/nxp/src/spi/adsd3500-spi.c
+++ b/drivers/adsd3500/nxp/src/spi/adsd3500-spi.c
@@ -1318,7 +1318,7 @@ static int adsd3500_set_format(struct v4l2_subdev *sd,
 
 	framefmt->width = crop->width;
 	framefmt->height = crop->height;
-	framefmt->code = new_mode->code;
+	framefmt->code = format->format.code;
 	framefmt->field = V4L2_FIELD_NONE;
 	framefmt->colorspace = V4L2_COLORSPACE_RAW;
 

--- a/sdcard-images-utils/nxp/patches/linux-imx/0068-drivers-media-i2c-adsd3500.c-Update-the-pixel-format.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0068-drivers-media-i2c-adsd3500.c-Update-the-pixel-format.patch
@@ -1,0 +1,28 @@
+From 7782f5522d5fe9acd251273356d228e31bcb513c Mon Sep 17 00:00:00 2001
+From: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Thu, 13 Mar 2025 20:19:19 +0530
+Subject: [PATCH 1/2] drivers: media: i2c: adsd3500.c: Update the pixel format
+ code to support the RAW8 and RAW12 for the resolution which has the same
+ width as well as height
+
+Signed-off-by: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/i2c/adsd3500.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/adsd3500.c b/drivers/media/i2c/adsd3500.c
+index 5e9122066cd4..89bc13f58f7f 100644
+--- a/drivers/media/i2c/adsd3500.c
++++ b/drivers/media/i2c/adsd3500.c
+@@ -1188,7 +1188,7 @@ static int adsd3500_set_format(struct v4l2_subdev *sd,
+ 
+ 	framefmt->width = crop->width;
+ 	framefmt->height = crop->height;
+-	framefmt->code = new_mode->code;
++	framefmt->code = format->format.code;
+ 	framefmt->field = V4L2_FIELD_NONE;
+ 	framefmt->colorspace = V4L2_COLORSPACE_RAW;
+ 
+-- 
+2.28.0
+

--- a/sdcard-images-utils/nxp/patches/linux-imx/0069-drivers-media-spi-adsd3500-spi.c-resolution-with-sam.patch
+++ b/sdcard-images-utils/nxp/patches/linux-imx/0069-drivers-media-spi-adsd3500-spi.c-resolution-with-sam.patch
@@ -1,0 +1,27 @@
+From e1db9f240f2f99d9d28eb2fe65157e22f4b10587 Mon Sep 17 00:00:00 2001
+From: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Thu, 13 Mar 2025 20:22:44 +0530
+Subject: [PATCH 2/2] drivers: media: spi: adsd3500-spi.c: resolution with same
+ width and height should support the different pixel format
+
+Signed-off-by: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/spi/adsd3500-spi.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/spi/adsd3500-spi.c b/drivers/media/spi/adsd3500-spi.c
+index 3020bbe8c116..d290ab6fe719 100644
+--- a/drivers/media/spi/adsd3500-spi.c
++++ b/drivers/media/spi/adsd3500-spi.c
+@@ -1318,7 +1318,7 @@ static int adsd3500_set_format(struct v4l2_subdev *sd,
+ 
+ 	framefmt->width = crop->width;
+ 	framefmt->height = crop->height;
+-	framefmt->code = new_mode->code;
++	framefmt->code = format->format.code;
+ 	framefmt->field = V4L2_FIELD_NONE;
+ 	framefmt->colorspace = V4L2_COLORSPACE_RAW;
+ 
+-- 
+2.28.0
+


### PR DESCRIPTION
The ADSD3500 I2C and SPI driver supports the different pixel format such as BA81, BG12 etc. for the same resolution