### PR TITLE
Nvidia camera - add external fsync and interrupt gpio support

### DIFF
--- a/sdcard-images-utils/nvidia/patches/hardware/nvidia/t23x/nv-public/0006-overlay-t23x-add-the-interrupt-gpio-pin.patch
+++ b/sdcard-images-utils/nvidia/patches/hardware/nvidia/t23x/nv-public/0006-overlay-t23x-add-the-interrupt-gpio-pin.patch
@@ -1,0 +1,25 @@
+From 0ade0ad342d7fe7f9f21525f9bc52342bde855c7 Mon Sep 17 00:00:00 2001
+From: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Thu, 17 Apr 2025 14:12:02 +0530
+Subject: [PATCH]  overlay: t23x: adsd3500-dual: add the interrupt gpio pin
+
+Signed-off-by: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts b/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts
+index 8f296cd..d30547d 100644
+--- a/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts
++++ b/overlay/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts
+@@ -133,6 +133,7 @@
+ 						sensor_model ="adsd3500";
+ 						/* Define any required hw resources needed by driver */
+ 						/* ie. clocks, io pins, power sources */
++						interrupt-gpios = <&gpio TEGRA234_MAIN_GPIO(P, 0) GPIO_ACTIVE_LOW>;
+ 						pwms = <&pwm 0 50000000>;
+ 						pwm-names = "fsync";
+ 
+-- 
+2.25.1
+

--- a/sdcard-images-utils/nvidia/patches/kernel/kernel-jammy-src/0006-arch-arm64-configs-defconfig-add-kernel-local-versio.patch
+++ b/sdcard-images-utils/nvidia/patches/kernel/kernel-jammy-src/0006-arch-arm64-configs-defconfig-add-kernel-local-versio.patch
@@ -1,0 +1,25 @@
+From 18aa9db3f580be2f31d72998a10c7ea8aeb556fb Mon Sep 17 00:00:00 2001
+From: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Thu, 17 Apr 2025 15:17:25 +0530
+Subject: [PATCH] arch: arm64: configs: defconfig: add kernel local version
+ suffix name as "adi"
+
+Signed-off-by: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ arch/arm64/configs/defconfig | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/configs/defconfig b/arch/arm64/configs/defconfig
+index 126a863963cc..3aac17cf1b6e 100644
+--- a/arch/arm64/configs/defconfig
++++ b/arch/arm64/configs/defconfig
+@@ -1,4 +1,5 @@
+-# CONFIG_LOCALVERSION_AUTO is not set
++CONFIG_LOCALVERSION_AUTO=n
++CONFIG_LOCALVERSION="-adi"
+ CONFIG_SYSVIPC=y
+ CONFIG_POSIX_MQUEUE=y
+ CONFIG_AUDIT=y
+-- 
+2.25.1
+

--- a/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0008-drivers-media-i2c-nv_adsd3500.c-request-gpio-as-inte.patch
+++ b/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0008-drivers-media-i2c-nv_adsd3500.c-request-gpio-as-inte.patch
@@ -1,0 +1,298 @@
+From cae422c3328fdca45420eca1fd6ea13367c99ce1 Mon Sep 17 00:00:00 2001
+From: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Thu, 17 Apr 2025 14:04:53 +0530
+Subject: [PATCH] drivers: media: i2c: nv_adsd3500.c: request gpio as interrupt
+ and assign the irq handler
+
+Signed-off-by: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/i2c/adsd3500_regs.h |   3 +
+ drivers/media/i2c/nv_adsd3500.c   | 184 +++++++++++++++++++++++++++++-
+ 2 files changed, 186 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/adsd3500_regs.h b/drivers/media/i2c/adsd3500_regs.h
+index a8e7378a..6c432d5c 100644
+--- a/drivers/media/i2c/adsd3500_regs.h
++++ b/drivers/media/i2c/adsd3500_regs.h
+@@ -45,6 +45,7 @@
+ #define GET_IMAGER_CONFIDENCE_TRSHLD        0x0016
+ #define GET_IMAGER_JBLF_STATE               0x0017
+ #define GET_IMAGER_JBLF_FILT_SIZE           0x0018
++#define GET_IMAGER_STATUS_CMD		    0x0020
+ 
+ #define SET_FRAMERATE_CMD                   0x0022
+ #define GET_FRAMERATE_CMD                   0x0023
+@@ -63,5 +64,7 @@
+ #define ADSD3500_CHIP_ID                    0x5931
+ #define PWM_TRIGGER			    0x0000
+ #define INTR_TRIGGER			    0x0001
++#define USER_TASK 			    _IOW('A',1,int32_t*)
++#define SIGETX				    44
+ 
+ #endif /* _ADI_ADSD3500_REGS_H_ */
+diff --git a/drivers/media/i2c/nv_adsd3500.c b/drivers/media/i2c/nv_adsd3500.c
+index daa92eea..379a03f4 100644
+--- a/drivers/media/i2c/nv_adsd3500.c
++++ b/drivers/media/i2c/nv_adsd3500.c
+@@ -17,6 +17,7 @@
+ #include <linux/of_device.h>
+ #include <linux/of_gpio.h>
+ #include <linux/regmap.h>
++#include <linux/debugfs.h>
+ #include <media/v4l2-ctrls.h>
+ #include <media/v4l2-subdev.h>
+ 
+@@ -69,9 +70,14 @@ struct adsd3500 {
+ 	bool 				streaming;
+ 	s64 				framerate;
+ 	u8 				curr_sync_mode;
++	int 				gpio;
++	int				irq;
++	int                             signalnum;
+ 
+ 	struct v4l2_ctrl 		*ctrls[10];
+ 	struct pwm_device 		*pwm_fsync;
++	struct dentry 			*debugfs;
++	struct task_struct 		*task;
+ };
+ 
+ #define V4L2_CID_ADSD3500_OPERATING_MODE  (V4L2_CID_USER_ADITOF_BASE + 0)
+@@ -83,6 +89,8 @@ struct adsd3500 {
+ #define V4L2_CID_ADSD3500_DEPTH_EN (V4L2_CID_USER_ADITOF_BASE + 6)
+ #define V4L2_CID_ADSD3500_SYNC_MODE (V4L2_CID_USER_ADITOF_BASE + 7)
+ 
++ssize_t debug_read(struct file *file, char __user *buff, size_t count, loff_t *offset);
++ssize_t debug_write(struct file *file, const char __user *buff, size_t count, loff_t *offset);
+ static int adsd3500_sync_mode(struct adsd3500 *adsd3500, s32 val);
+ 
+ static const struct reg_sequence adsd3500_powerup_setting[] = {
+@@ -99,6 +107,112 @@ static const s64 link_freq_tbl[] = {
+ 	1250000000,
+ };
+ 
++static int debug_open(struct inode *inode, struct file *file)
++{
++	struct adsd3500 *adsd3500;
++
++	if (inode->i_private)
++		file->private_data = inode->i_private;
++
++	adsd3500 = (struct adsd3500 *) file->private_data;
++
++	dev_dbg(adsd3500->dev, "Entered debugfs file open\n");
++
++	return 0;
++}
++
++static int debug_release(struct inode *inode, struct file *file)
++{
++	struct adsd3500 *adsd3500;
++	struct task_struct *release_task = get_current();
++
++	if (inode->i_private)
++		file->private_data = inode->i_private;
++
++	adsd3500 = (struct adsd3500 *) file->private_data;
++
++	dev_dbg(adsd3500->dev, "Entered debugfs file close\n");
++	if(release_task == adsd3500->task) {
++		adsd3500->task = NULL;
++	}
++
++	return 0;
++}
++
++ssize_t debug_read(struct file *file, char __user *buff, size_t count, loff_t *offset){
++
++	struct adsd3500 *adsd3500 = file->private_data;
++	unsigned int read_val;
++	unsigned int len;
++	int ret;
++	char data[16];
++
++	dev_dbg(adsd3500->dev, "Entered debugfs file read\n");
++	ret = regmap_read(adsd3500->regmap, GET_IMAGER_STATUS_CMD, &read_val);
++	if (ret < 0) {
++		dev_err(adsd3500->dev, "Read of get status cmd failed.\n");
++		len = snprintf(data, sizeof(data), "Read failed\n");
++	}
++	else{
++		dev_dbg(adsd3500->dev, "Read the error status: %.4X\n", read_val);
++		len = snprintf(data, sizeof(data), "0x%.4X\n",read_val);
++	}
++	return simple_read_from_buffer(buff, count, offset, data, len);
++
++}
++
++ssize_t debug_write(struct file *file, const char __user *buff, size_t count, loff_t *offset){
++
++	struct adsd3500 *adsd3500 = file->private_data;
++
++	dev_dbg(adsd3500->dev, "Entered debugfs file write\n");
++
++	return count;
++}
++
++static long debug_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
++{
++	struct adsd3500 *adsd3500;
++
++	adsd3500 = (struct adsd3500 *) file->private_data;
++
++	dev_dbg(adsd3500->dev, "Entered debugfs ioctl\n");
++	if (cmd == USER_TASK) {
++		dev_dbg(adsd3500->dev, "Registered user task\n");
++		adsd3500->task = get_current();
++		adsd3500->signalnum = SIGETX;
++	}
++
++	return 0;
++}
++
++static const struct file_operations adsd3500_debug_fops = {
++	.owner 	= THIS_MODULE,
++	.open   = debug_open,
++	.read 	= debug_read,
++	.write  = debug_write,
++	.unlocked_ioctl = debug_ioctl,
++	.release= debug_release,
++};
++
++static irqreturn_t adsd3500_irq_handler(int irq,void *priv)
++{
++
++	struct adsd3500 *adsd3500 = (struct adsd3500 *) priv;
++
++	dev_dbg(adsd3500-> dev, "Entered ADSD3500 IRQ handler\n");
++
++	if (adsd3500->task != NULL) {
++		dev_dbg(adsd3500->dev, "Sending signal to app\n");
++		if(send_sig_info(SIGETX, SEND_SIG_PRIV, adsd3500->task) < 0) {
++			dev_err(adsd3500->dev, "Unable to send signal\n");
++		}
++	}
++
++	return IRQ_HANDLED;
++
++}
++
+ /* Elements of the structure must be ordered ascending by width & height */
+ static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
+ 	{ //RAW12 12BPP ADSD3030
+@@ -760,6 +874,50 @@ static int adsd3500_set_frame_rate(struct adsd3500 *priv, s64 val)
+ 	return ret;
+ }
+ 
++static int adsd3500_configure_interrupt(struct adsd3500 *adsd3500){
++
++	struct device *dev = adsd3500->dev;
++	struct i2c_client *client = adsd3500->i2c_client;
++	struct device_node *np = client->dev.of_node;
++	int gpio, ret = 0;
++
++	dev_info(dev, "Entered: %s\n", __func__);
++	gpio = of_get_named_gpio(np, "interrupt-gpios", 0);
++	if (!gpio_is_valid(gpio)){
++		dev_err(&client->dev, "interrupt-gpios not found %d\n", gpio);
++		return ret;
++	}
++	adsd3500->gpio = gpio;
++
++	ret = gpio_request(adsd3500->gpio, "adsd3500_irq");
++	if (ret){
++		dev_err(&client->dev, "Unable to get adsd3500 gpio\n");
++		return ret;
++	}
++
++	ret = gpio_direction_input(adsd3500->gpio);
++	if (ret < 0) {
++		dev_err(&client->dev,"Unable to set adsd3500 gpio as input\n");
++		return ret;
++	}
++
++	ret = gpio_to_irq(adsd3500->gpio);
++	if (ret < 0){
++		dev_err(&client->dev, "Unable to map GPIO adsd3500 gpio to an IRQ\n");
++		return ret;
++	}
++	adsd3500->irq = ret;
++
++	ret = request_irq(adsd3500->irq, adsd3500_irq_handler,
++			IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING, "adsd3500", adsd3500);
++	if (ret) {
++		dev_err(&client->dev, "Failed to request adsd3500 irq\n");
++	}
++
++	return ret;
++
++}
++
+ static int adsd3500_sync_mode(struct adsd3500 *adsd3500, s32 val){
+ 
+ 	struct device *dev = adsd3500->dev;
+@@ -776,6 +934,8 @@ static int adsd3500_sync_mode(struct adsd3500 *adsd3500, s32 val){
+ 			dev_err(&client->dev, "Failed to get the pwm device\n");
+ 			goto error;
+ 		}
++		free_irq(adsd3500->irq, adsd3500);
++		gpio_free(adsd3500->gpio);
+ 
+ 		pwm_init_state(adsd3500->pwm_fsync, &state);
+ 		state.polarity = PWM_POLARITY_NORMAL;
+@@ -792,6 +952,8 @@ static int adsd3500_sync_mode(struct adsd3500 *adsd3500, s32 val){
+ 		if(ret) {
+ 			dev_err(&client->dev, "Failed to change the PWM state\n");
+ 		}
++		ret = adsd3500_configure_interrupt(adsd3500);
++
+ 	}
+ 	else{
+ 		dev_err(dev, "Invalid sync mode %d\n", adsd3500->curr_sync_mode);
+@@ -877,6 +1039,17 @@ const static struct of_device_id adsd3500_of_match[] = {
+ 	{ /* sentinel */ }
+ };
+ 
++static int adsd3500_debugfs_init(struct adsd3500 *priv){
++
++	priv->debugfs = debugfs_create_dir("adsd3500", NULL);
++	if(!priv->debugfs)
++		return -ENOMEM;
++
++	debugfs_create_file("value", 0660, priv->debugfs, priv, &adsd3500_debug_fops);
++
++	return 0;
++}
++
+ static struct camera_common_pdata *adsd3500_parse_dt(struct i2c_client *client,
+ 				struct camera_common_data *s_data)
+ {
+@@ -1057,9 +1230,17 @@ static int adsd3500_probe(struct i2c_client *client,
+ 
+ 	v4l2_i2c_subdev_init(priv->sd, client, &adsd3500_subdev_ops);
+ 
++	ret= adsd3500_debugfs_init(priv);
++	if(ret < 0){
++		dev_err(&client->dev, "Failed to initialize debugfs.\n");
++		return ret;
++	}
++
+ 	ret = adsd3500_ctrls_init(priv);
+-	if (ret)
++	if (ret < 0){
++		dev_err(&client->dev, "Failed to initialze v4l2 ctrls\n");
+ 		return ret;
++	}
+ 
+ 	priv->sd->internal_ops = &adsd3500_subdev_internal_ops;
+ 	priv->sd->flags |= V4L2_SUBDEV_FL_HAS_DEVNODE;
+@@ -1114,6 +1295,7 @@ static int adsd3500_remove(struct i2c_client *client)
+ 	v4l2_ctrl_handler_free(&priv->ctrl_handler);
+ 	camera_common_cleanup(priv->s_data);
+ 	mutex_destroy(&priv->lock);
++	debugfs_remove(priv->debugfs);
+ 
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+ 	return 0;
+-- 
+2.25.1
+

--- a/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0009-drivers-media-i2c-nv_adsd3500.c-add-the-enable-fsync.patch
+++ b/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0009-drivers-media-i2c-nv_adsd3500.c-add-the-enable-fsync.patch
@@ -1,0 +1,92 @@
+From 160aaac8403f727a8055652d3b9287154371cd4a Mon Sep 17 00:00:00 2001
+From: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Fri, 18 Apr 2025 11:23:59 +0530
+Subject: [PATCH] drivers: media: i2c: nv_adsd3500.c: add the enable fsync
+ trigger control
+
+Signed-off-by: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/i2c/adsd3500_regs.h |  2 +-
+ drivers/media/i2c/nv_adsd3500.c   | 31 +++++++++++++++++++++++++++++++
+ 2 files changed, 32 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/i2c/adsd3500_regs.h b/drivers/media/i2c/adsd3500_regs.h
+index 6c432d5c..6e7a0801 100644
+--- a/drivers/media/i2c/adsd3500_regs.h
++++ b/drivers/media/i2c/adsd3500_regs.h
+@@ -49,8 +49,8 @@
+ 
+ #define SET_FRAMERATE_CMD                   0x0022
+ #define GET_FRAMERATE_CMD                   0x0023
++#define ENABLE_FSYNC_TRIGGER		    0x0025
+ 
+-#define GET_STATUS_CMD                      0x0020
+ 
+ #define READ_REGISTER_CMD                   0xFFFF
+ #define WRITE_REGISTER_CMD                  0xFFFF
+diff --git a/drivers/media/i2c/nv_adsd3500.c b/drivers/media/i2c/nv_adsd3500.c
+index 379a03f4..b21c0468 100644
+--- a/drivers/media/i2c/nv_adsd3500.c
++++ b/drivers/media/i2c/nv_adsd3500.c
+@@ -88,6 +88,7 @@ struct adsd3500 {
+ #define V4L2_CID_ADSD3500_AB_AVG (V4L2_CID_USER_ADITOF_BASE + 5)
+ #define V4L2_CID_ADSD3500_DEPTH_EN (V4L2_CID_USER_ADITOF_BASE + 6)
+ #define V4L2_CID_ADSD3500_SYNC_MODE (V4L2_CID_USER_ADITOF_BASE + 7)
++#define V4L2_CID_ADSD3500_FSYNC_TRIGGER (V4L2_CID_USER_ADITOF_BASE + 8)
+ 
+ ssize_t debug_read(struct file *file, char __user *buff, size_t count, loff_t *offset);
+ ssize_t debug_write(struct file *file, const char __user *buff, size_t count, loff_t *offset);
+@@ -399,6 +400,23 @@ static const struct regmap_config adsd3500_regmap_config = {
+ 	.readable_reg = adsd3500_regmap_accessible_reg,
+ };
+ 
++static int adsd3500_set_fsync_trigger(struct adsd3500 *adsd3500, s32 val)
++{
++	int ret;
++
++	if(adsd3500->curr_sync_mode == PWM_TRIGGER){
++		dev_info(adsd3500->dev, "Entered: %s value = %d\n",__func__, val);
++		ret = regmap_write(adsd3500->regmap, ENABLE_FSYNC_TRIGGER, val);
++		if (ret < 0){
++			dev_err(adsd3500->dev, "Write of ENABLE_FSYNC_TRIGGER command failed.\n");
++			return ret;
++		}
++	}
++
++	return ret;
++}
++
++
+ static int _adsd3500_power_on(struct camera_common_data *s_data)
+ {
+ 	struct adsd3500 *adsd3500 = (struct adsd3500 *)s_data->priv;
+@@ -573,6 +591,9 @@ static int adsd3500_s_ctrl(struct v4l2_ctrl *ctrl)
+ 	case V4L2_CID_ADSD3500_SYNC_MODE:
+ 		ret = adsd3500_sync_mode(adsd3500, ctrl->val);
+ 		break;
++	case V4L2_CID_ADSD3500_FSYNC_TRIGGER:
++		ret = adsd3500_set_fsync_trigger(adsd3500, ctrl->val);
++		break;
+ 	case TEGRA_CAMERA_CID_FRAME_RATE:
+ 		ret = adsd3500_set_frame_rate(adsd3500, *ctrl->p_new.p_s64);
+ 		break;
+@@ -693,6 +714,16 @@ static const struct v4l2_ctrl_config adsd3500_ctrls[] = {
+ 		.max    	= 2,
+ 		.step   	= 1,
+ 	},
++	{
++		.ops            = &adsd3500_ctrl_ops,
++		.id             = V4L2_CID_ADSD3500_FSYNC_TRIGGER,
++		.name           = "Fsync Trigger",
++		.type           = V4L2_CTRL_TYPE_INTEGER,
++		.def            = 0,
++		.min            = 0,
++		.max            = 2,
++		.step           = 1,
++	},
+ 	{
+ 		.ops 		= &adsd3500_ctrl_ops,
+ 		.id 		= TEGRA_CAMERA_CID_FRAME_RATE,
+-- 
+2.25.1
+

--- a/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0010-drivers-media-i2c-nv_adsd3500.c-pwm-device-is-added-.patch
+++ b/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0010-drivers-media-i2c-nv_adsd3500.c-pwm-device-is-added-.patch
@@ -1,0 +1,98 @@
+From 54ceef49b34f90aca601fd20eb5aa65b45c99969 Mon Sep 17 00:00:00 2001
+From: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Fri, 18 Apr 2025 15:29:51 +0530
+Subject: [PATCH] drivers: media: i2c: nv_adsd3500.c: pwm device is added as an
+ optional property
+
+Signed-off-by: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/i2c/nv_adsd3500.c | 31 ++++++++++++++++++++++---------
+ 1 file changed, 22 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/media/i2c/nv_adsd3500.c b/drivers/media/i2c/nv_adsd3500.c
+index b21c0468..1030b099 100644
+--- a/drivers/media/i2c/nv_adsd3500.c
++++ b/drivers/media/i2c/nv_adsd3500.c
+@@ -74,7 +74,7 @@ struct adsd3500 {
+ 	int				irq;
+ 	int                             signalnum;
+ 
+-	struct v4l2_ctrl 		*ctrls[10];
++	struct v4l2_ctrl 		*ctrls[15];
+ 	struct pwm_device 		*pwm_fsync;
+ 	struct dentry 			*debugfs;
+ 	struct task_struct 		*task;
+@@ -404,6 +404,11 @@ static int adsd3500_set_fsync_trigger(struct adsd3500 *adsd3500, s32 val)
+ {
+ 	int ret;
+ 
++	if(adsd3500->pwm_fsync == NULL){
++		dev_err(adsd3500->dev, "Failed to get the pwm device\n");
++		return -ENODEV;
++	}
++
+ 	if(adsd3500->curr_sync_mode == PWM_TRIGGER){
+ 		dev_info(adsd3500->dev, "Entered: %s value = %d\n",__func__, val);
+ 		ret = regmap_write(adsd3500->regmap, ENABLE_FSYNC_TRIGGER, val);
+@@ -817,7 +822,7 @@ static int adsd3500_start_streaming(struct adsd3500 *adsd3500)
+ {
+ 	int ret;
+ 
+-	if(adsd3500->curr_sync_mode == PWM_TRIGGER){
++	if(adsd3500->pwm_fsync != NULL && adsd3500->curr_sync_mode == PWM_TRIGGER){
+ 		ret = pwm_enable(adsd3500->pwm_fsync);
+ 		if (ret)
+ 			dev_err(adsd3500->dev, "Could not enable FSYNC PWM\n");
+@@ -835,7 +840,7 @@ static int adsd3500_stop_streaming(struct adsd3500 *adsd3500)
+ {
+ 	int ret;
+ 
+-	if(adsd3500->curr_sync_mode == PWM_TRIGGER){
++	if(adsd3500->pwm_fsync != NULL && adsd3500->curr_sync_mode == PWM_TRIGGER){
+ 		pwm_disable(adsd3500->pwm_fsync);
+ 		return ret;
+ 	}
+@@ -891,10 +896,12 @@ static int adsd3500_set_frame_rate(struct adsd3500 *priv, s64 val)
+ 
+ 	priv->framerate = val;
+ 
+-	pwm_init_state(priv->pwm_fsync, &state);
+-	state.period = DIV_ROUND_UP(1 * NSEC_PER_SEC, priv->framerate);
+-	pwm_set_relative_duty_cycle(&state, 50, 100);
+-	ret = pwm_apply_state(priv->pwm_fsync, &state);
++	if(priv->pwm_fsync != NULL){
++		pwm_init_state(priv->pwm_fsync, &state);
++		state.period = DIV_ROUND_UP(1 * NSEC_PER_SEC, priv->framerate);
++		pwm_set_relative_duty_cycle(&state, 50, 100);
++		ret = pwm_apply_state(priv->pwm_fsync, &state);
++	}
+ 
+ 	ret = regmap_write(priv->regmap, SET_FRAMERATE_CMD, val);
+ 	if (ret < 0)
+@@ -956,6 +963,11 @@ static int adsd3500_sync_mode(struct adsd3500 *adsd3500, s32 val){
+ 	struct pwm_state state;
+ 	int ret;
+ 
++	if(adsd3500->pwm_fsync == NULL){
++		dev_err(dev, "Failed to get the pwm device\n");
++		return -ENODEV;
++	}
++
+ 	dev_info(dev, "Entered: %s Value: %d\n", __func__, val);
+ 	adsd3500->curr_sync_mode = val;
+ 
+@@ -1111,8 +1123,9 @@ static struct camera_common_pdata *adsd3500_parse_dt(struct i2c_client *client,
+ 
+ 	adsd3500->pwm_fsync = devm_pwm_get(&client->dev, NULL);
+ 	if(IS_ERR(adsd3500->pwm_fsync)){
+-		dev_err(&client->dev, "Failed to get the pwm device\n");
+-		goto error;
++		dev_warn(&client->dev, "Failed to get the pwm device\n");
++		adsd3500->pwm_fsync = NULL;
++		return board_priv_pdata;
+ 	}
+ 
+ 	adsd3500->framerate = ADSD3500_DEFAULT_FPS;
+-- 
+2.25.1
+

--- a/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0011-drivers-media-i2c-nv_adsd3500.c-deleted-set-frame-ra.patch
+++ b/sdcard-images-utils/nvidia/patches/nvidia-oot/drivers/0011-drivers-media-i2c-nv_adsd3500.c-deleted-set-frame-ra.patch
@@ -1,0 +1,47 @@
+From 74c524ea62e815a594dada66369b612a365d979e Mon Sep 17 00:00:00 2001
+From: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+Date: Mon, 21 Apr 2025 12:54:43 +0530
+Subject: [PATCH] drivers: media: i2c: nv_adsd3500.c: deleted set frame rate
+ command from the power on function
+
+Signed-off-by: Sivasubramaniyan Padmanaban <sivasubramaniyan.padmanaban@analog.com>
+---
+ drivers/media/i2c/nv_adsd3500.c | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/media/i2c/nv_adsd3500.c b/drivers/media/i2c/nv_adsd3500.c
+index 96a1f171..95233645 100644
+--- a/drivers/media/i2c/nv_adsd3500.c
++++ b/drivers/media/i2c/nv_adsd3500.c
+@@ -405,7 +405,7 @@ static int adsd3500_set_fsync_trigger(struct adsd3500 *adsd3500, s32 val)
+ 	int ret;
+ 
+ 	if(adsd3500->pwm_fsync == NULL){
+-		dev_err(adsd3500->dev, "Failed to get the pwm device\n");
++		dev_warn(adsd3500->dev, "Failed to get the pwm device\n");
+ 		return -ENODEV;
+ 	}
+ 
+@@ -454,10 +454,6 @@ static int _adsd3500_power_on(struct camera_common_data *s_data)
+ 		return ret;
+ 	}
+ 
+-	ret = regmap_write(adsd3500->regmap, SET_FRAMERATE_CMD, adsd3500->framerate);
+-	if (ret < 0)
+-		dev_err(adsd3500->dev, "SET_FRAMERATE command failed.\n");
+-
+ 	return 0;
+ }
+ 
+@@ -964,7 +960,7 @@ static int adsd3500_sync_mode(struct adsd3500 *adsd3500, s32 val){
+ 	int ret;
+ 
+ 	if(adsd3500->pwm_fsync == NULL){
+-		dev_err(dev, "Failed to get the pwm device\n");
++		dev_warn(dev, "Failed to get the pwm device\n");
+ 		return -ENODEV;
+ 	}
+ 
+-- 
+2.25.1
+

--- a/sdcard-images-utils/nvidia/scripts/system_upgrade/apply_patch.sh
+++ b/sdcard-images-utils/nvidia/scripts/system_upgrade/apply_patch.sh
@@ -194,7 +194,7 @@ EOF
 
 function set_default_boot_label()
 {
-        echo "Setting the default label name to ADSD3500+ADSD3100"
+        echo "Setting the default label name to ADSD3500-DUAL+ADSD3100"
         sudo sed -i "s/^DEFAULT .*/DEFAULT ADSD3500-DUAL+ADSD3100/" ${extlinux_conf_file}
 }
 


### PR DESCRIPTION
1. add support to configure the external FSYNC with default fps
2. probing the interrupt GPIO
3. Custom v4l2-ctrl to switching between the external FSYNC and interrupt GPIO
4. The custom kernel version name adds the suffix "adi"
5. Handled the PWM device when the PWM is not mentioned in the device tree
6. Commented the build SDK function in the apply_patch.sh script