### PR TITLE
Fix for point cloud to for point occlusion based on depth.

### DIFF
--- a/examples/tof-viewer/include/ADIMainWindow.h
+++ b/examples/tof-viewer/include/ADIMainWindow.h
@@ -626,6 +626,7 @@ class ADIMainWindow {
     unsigned int ab_video_texture = 0;
     unsigned int depth_video_texture = 0;
     unsigned int pointCloud_video_texture = 0;
+    GLuint m_gl_pc_depthTex;
     bool setTempWinPositionOnce = true;
     bool setABWinPositionOnce = true;
     bool setDepthWinPositionOnce = true;


### PR DESCRIPTION
Addresses a critical issue in the viewer. The point cloud has never been shown correctly. Occluded points were not be occluded based on depth, but position in array. 

Also, the reset state of the camera and model now look into the scene instead of from behind.