### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ For more details about the SDK check the links below:
 | tof-viewer | <a href="examples/tof-viewer"> C++ </a> | Graphical User interface for visualising stream from depth camera |
 | data-collect | <a href="examples/data_collect"> C++ </a> | A command line application that takes in command line input arguments (like number of frames, mode to be set, folder location to save frame data) and captures the frames and stores in path provided |
 | first-frame | <a href="examples/first-frame"> C++ </a> <br> <a href="bindings/python/examples/first_frame"> Python </a> | An example code that shows the steps required to get to the point where camera frames can be captured. |
-| low_level_example | <a href="bindings/python/examples/low_level_example"> Python</a> | A simple example of how to get access to the low-level API of the camera. |
-| ROS2 CPP Wrapper | <a href="bindings/ros2/"> ROS2/C++</a> | ROS2 binding that publishes topics |
 
 ## Other Examples
 | Example | Language | Description |

--- a/bindings/python/examples/gesture_rec/readme.md
+++ b/bindings/python/examples/gesture_rec/readme.md
@@ -1,4 +1,4 @@
-# Gesture recognition example
+# Gesture recognition example (DEPRECATED)
 
 ### Overview
 This example is intended to present the gesture recognition for the Rock-Paper-Scissor game.

--- a/bindings/python/examples/readme.md
+++ b/bindings/python/examples/readme.md
@@ -9,6 +9,4 @@ The examples in this directory provide sample Python applications to demonstrate
 | Directory/File | Description |
 | --------- | ----------- |
 | first_frame | Python example to capture a frame |
-| dnn | Simple object detection example in Python |
-| showPointCloud | Simple Python example of using Open3D to create and show a pointcloud from aditof frames  |
 | streaming | Use PyGame to show depth frames in real-time |

--- a/bindings/python/examples/showPointCloud/readme.md
+++ b/bindings/python/examples/showPointCloud/readme.md
@@ -1,4 +1,4 @@
-# First frame Example
+# First frame Example (DEPRECATED)
 
 ### Overview
 This example shows how to use Open3d to create and show a pointcloud from aditof frames 

--- a/doc/itof/linux_build_instructions.md
+++ b/doc/itof/linux_build_instructions.md
@@ -1,6 +1,6 @@
 # Linux Host Build Instructions
 
-**Please note, use the applicable tag, when cloning, and release version when getting the latest depth compute library files for the embedded system. As of writing, version 6.0.0 of the release is available as well as tag v6.0.0.**
+**Please note, use the applicable tag, when cloning, and release version when getting the latest depth compute library files for the embedded system. As of writing, version 6.1.0 of the release is available as well as tag v6.1.0.**
 
 ## Building the SDK only
 
@@ -33,15 +33,15 @@ Please note, ensure you are using the intended branch.
 
 See [here](../../cmake/readme.md) for details on the cmake options.
 
-Choose the branch as needed. In our example below we are using the branch/tag v6.0.0:
-* --branch v6.0.0
+Choose the branch as needed. In our example below we are using the branch/tag v6.1.0:
+* --branch v6.1.0
 
 To build:
 * the examples add the CMake option: -DWITH_EXAMPLES=on
 * the documentation add the CMake optionL -DWITH_DOC=on 
 
 ```console
-git clone --branch v6.0.0 https://github.com/analogdevicesinc/ToF
+git clone --branch v6.1.0 https://github.com/analogdevicesinc/ToF
 cd ToF
 git submodule update --init --recursive
 mkdir build && cd build

--- a/doc/itof/nxp_build_instructions.md
+++ b/doc/itof/nxp_build_instructions.md
@@ -46,7 +46,7 @@ Based on the following scenarios you will be able to do the following:
 Please note, ensure you are using the intended branch.
 
 ```console
-git clone --branch v5.0.0  https://github.com/analogdevicesinc/ToF
+git clone --branch v6.1.0  https://github.com/analogdevicesinc/ToF
 cd ToF
 git submodule update --init
 mkdir build && cd build
@@ -59,7 +59,7 @@ make -j4
 Please note, ensure you are using the intended branch.
 
 ```console
-git clone --branch v5.0.0  https://github.com/analogdevicesinc/ToF
+git clone --branch v6.1.0  https://github.com/analogdevicesinc/ToF
 cd ToF
 git submodule update --init
 mkdir build && cd build

--- a/doc/itof/windows_build_instructions.md
+++ b/doc/itof/windows_build_instructions.md
@@ -25,7 +25,7 @@ See [here](../../cmake/readme.md) for details on the cmake options.
 ### Build SDK with examples and in Visual Studio
 - Generate the VisualStudio solution
 ```console
-git clone --branch v5.0.0 https://github.com/analogdevicesinc/ToF
+git clone --branch v6.1.0 https://github.com/analogdevicesinc/ToF
 cd ToF
 git submodule update --init
 mkdir build

--- a/scripts/windows/readme.md
+++ b/scripts/windows/readme.md
@@ -14,11 +14,11 @@ Please use option -h or --help for further reference on how to change the defaul
 
 ## Clone Repo
 
-Choose the branch as needed. In our example below we are using the branch/tag v6.0.0:
-* --branch v6.0.0
+Choose the branch as needed. In our example below we are using the branch/tag v6.1.0:
+* --branch v6.1.0
 
 ```console
-git clone --branch v6.0.0 https://github.com/analogdevicesinc/ToF
+git clone --branch v6.1.0 https://github.com/analogdevicesinc/ToF
 cd ToF
 git submodule update --init --recursive
 ```


### PR DESCRIPTION
- Updated build instructions to reference branch v6.1.0.
- Removed ToF ROS and Low-level examples.
- Removed references to two unused Python examples.
- gesture_rec and showpointcloud python examples now listed as deprecated.