### PR TITLE
Viewer fps limit

### DIFF
--- a/examples/tof-viewer/include/ADIMainWindow.h
+++ b/examples/tof-viewer/include/ADIMainWindow.h
@@ -595,6 +595,9 @@ class ADIMainWindow {
     bool cameraOptionsTreeEnabled = true;
     bool pointCloudEnable = true;
 
+    const uint32_t MAX_FRAME_RATE = 25;
+    uint32_t m_max_frame_rate = MAX_FRAME_RATE;
+
     /**
 		* @brief Set any window a specific position
 		*/

--- a/examples/tof-viewer/src/ADIMainWindow.cpp
+++ b/examples/tof-viewer/src/ADIMainWindow.cpp
@@ -177,15 +177,18 @@ ADIMainWindow::ADIMainWindow() : m_skipNetworkCameras(true) {
                 m_cameraIp = "ip:" + m_cameraIp;
             }
         }
-        
-        const cJSON* json_camera_max_frame_rate =
+
+        const cJSON *json_camera_max_frame_rate =
             cJSON_GetObjectItemCaseSensitive(config_json, "max_frame_rate");
 
         m_max_frame_rate = 0;
         if (cJSON_IsNumber(json_camera_max_frame_rate)) {
-            m_max_frame_rate = static_cast<uint32_t>(json_camera_max_frame_rate->valueint);
+            m_max_frame_rate =
+                static_cast<uint32_t>(json_camera_max_frame_rate->valueint);
             if (m_max_frame_rate == 0 || m_max_frame_rate > MAX_FRAME_RATE) {
-                LOG(WARNING) << "Frame Rate, " << m_max_frame_rate << " too high for Viewer, dropping to " << MAX_FRAME_RATE;
+                LOG(WARNING)
+                    << "Frame Rate, " << m_max_frame_rate
+                    << " too high for Viewer, dropping to " << MAX_FRAME_RATE;
                 m_max_frame_rate = MAX_FRAME_RATE;
             }
         }
@@ -1473,8 +1476,7 @@ void ADIMainWindow::prepareCamera(uint8_t mode) {
         auto status = getActiveCamera()->adsd3500SetFrameRate(m_max_frame_rate);
         if (status != aditof::Status::OK) {
             LOG(ERROR) << "Could not set frame rate!";
-        }
-        else {
+        } else {
             LOG(INFO) << "Frame rate set to: " << m_max_frame_rate;
         }
     }

--- a/examples/tof-viewer/src/ADIMainWindow.cpp
+++ b/examples/tof-viewer/src/ADIMainWindow.cpp
@@ -177,6 +177,18 @@ ADIMainWindow::ADIMainWindow() : m_skipNetworkCameras(true) {
                 m_cameraIp = "ip:" + m_cameraIp;
             }
         }
+        
+        const cJSON* json_camera_max_frame_rate =
+            cJSON_GetObjectItemCaseSensitive(config_json, "max_frame_rate");
+
+        m_max_frame_rate = 0;
+        if (cJSON_IsNumber(json_camera_max_frame_rate)) {
+            m_max_frame_rate = static_cast<uint32_t>(json_camera_max_frame_rate->valueint);
+            if (m_max_frame_rate == 0 || m_max_frame_rate > MAX_FRAME_RATE) {
+                LOG(WARNING) << "Frame Rate, " << m_max_frame_rate << " too high for Viewer, dropping to " << MAX_FRAME_RATE;
+                m_max_frame_rate = MAX_FRAME_RATE;
+            }
+        }
 
         cJSON_Delete(config_json);
     }
@@ -1456,6 +1468,16 @@ void ADIMainWindow::prepareCamera(uint8_t mode) {
     aditof::CameraDetails camDetails;
     status = getActiveCamera()->getDetails(camDetails);
     int totalCaptures = camDetails.frameType.totalCaptures;
+
+    if (m_max_frame_rate != 0) {
+        auto status = getActiveCamera()->adsd3500SetFrameRate(m_max_frame_rate);
+        if (status != aditof::Status::OK) {
+            LOG(ERROR) << "Could not set frame rate!";
+        }
+        else {
+            LOG(INFO) << "Frame rate set to: " << m_max_frame_rate;
+        }
+    }
 
     status = getActiveCamera()->adsd3500GetFrameRate(expectedFPS);
 

--- a/examples/tof-viewer/tof-tools.config
+++ b/examples/tof-viewer/tof-tools.config
@@ -1,4 +1,5 @@
 {
     "skip_network_cameras": "off",
-    "camera_ip": "10.43.0.1"
+    "camera_ip": "10.43.0.1",
+	"max_frame_rate": 25
 }


### PR DESCRIPTION
Implementation of max frame rate in the viewer. 

* tof-tools.config has a new number parameter, max_frame_rate. 

* If this is present then this value will be used as the maximum frame   rate that is allowed for any mode. Where the Viewer considers the   maximum frame allowable to be 25fps. If max_frame_rate is over 25fps or 0, the maximum frame rate will be set to 25fps. 

* If this parameter is missing then the frame rate will be as set by the   CCB as master or default in the SDK if there is no CCB as master.