### PR TITLE
Zmq redesign

### DIFF
--- a/apps/server/server.cpp
+++ b/apps/server/server.cpp
@@ -417,15 +417,12 @@ void data_transaction() {
 void sigint_handler(int) {
     interrupted = 1;
 
-    LOG(INFO) << __func__ << " in siginit handler";
-
     if (sensors_are_created) {
         cleanup_sensors();
     }
     clientEngagedWithSensors = false;
 
     stop_stream_thread();
-    LOG(INFO) << "stop streaming thread is been done";
     close_zmq_connection();
 
     if (server_cmd) {


### PR DESCRIPTION
- Added timeout for **captureFramfromhardware**, **stop_stream_thread**.
- redesigned the logic of stopping server app when user press CTRL+C.
- made **adsd3500InterruptsQueue** thread safe by introducing mutex for it.