### PR TITLE
Run evalkit-doc instead of doc for doxygen

### DIFF
--- a/ci/azure/lib.sh
+++ b/ci/azure/lib.sh
@@ -88,7 +88,7 @@ check_cppcheck() {
 ############################################################################
 check_doxygen() {
     pushd ${WORK_DIR}/doc
-    (cd build && ! make doc 2>&1 | grep -E "warning:|error:") || {
+    (cd build && ! make evalkit-doc 2>&1 | grep -E "warning:|error:") || {
         echo_red "Documentation incomplete or errors in the generation of it have occured!"
         exit 1
     }


### PR DESCRIPTION
Based on a commit from 11.Dec.2024, the creation o doc was changed from 'doc' to 'evalkit-doc'
https://github.com/analogdevicesinc/ToF/commit/be3580454295aee4bb663259d84ed2656cfa488f
The .sh script was not updated accordingly and the CI failed for doxygen. 

