### PR TITLE
Potential fix for code scanning alert no. 80: Multiplication result converted to larger type

### DIFF
--- a/.github/workflows/automerge_main_to_dev.yml
+++ b/.github/workflows/automerge_main_to_dev.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - main
-
+      
+permissions:
+  contents: write
 jobs:
   merge:
     runs-on: ubuntu-latest

--- a/dependencies/third-party/imgui/src/imgui_widgets.cpp
+++ b/dependencies/third-party/imgui/src/imgui_widgets.cpp
@@ -2458,7 +2458,7 @@ bool ImGui::SliderBehaviorT(const ImRect& bb, ImGuiID id, ImGuiDataType data_typ
                 {
                     // For integer values we want the clicking position to match the grab box so we round above
                     // This code is carefully tuned to work with large values (e.g. high ranges of U64) while preserving this property..
-                    FLOATTYPE v_new_off_f = (v_max - v_min) * clicked_t;
+                    FLOATTYPE v_new_off_f = ((FLOATTYPE)(v_max - v_min)) * (FLOATTYPE)clicked_t;
                     TYPE v_new_off_floor = (TYPE)(v_new_off_f);
                     TYPE v_new_off_round = (TYPE)(v_new_off_f + (FLOATTYPE)0.5);
                     if (v_new_off_floor < v_new_off_round)


### PR DESCRIPTION
Potential fix for [https://github.com/analogdevicesinc/ToF/security/code-scanning/80](https://github.com/analogdevicesinc/ToF/security/code-scanning/80)

The best fix is to force the multiplication to occur in the wider floating type, not in a potentially narrower type inferred from operands.  
Specifically in `dependencies/third-party/imgui/src/imgui_widgets.cpp` around line 2461, cast one operand (or both) to `FLOATTYPE` before multiplication.

Use:

- `((FLOATTYPE)(v_max - v_min)) * (FLOATTYPE)clicked_t`

This preserves existing functionality while ensuring the multiplication is executed using `FLOATTYPE` precision/range from the start. No new includes, helper methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
